### PR TITLE
Update module name to raincatcher-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# FeedHenry WFM sync
+# FeedHenry Raincatcher sync
 
-A sync module for FeedHenry WFM providing :
+A sync module for FeedHenry Raincatcher providing :
 - A Server-side sync module
 - A Front-end (Angular Service) sync module
 
@@ -14,7 +14,7 @@ This module is packaged in a CommonJS format, exporting the name of the Angular 
 
 ```javascript
 angular.module('app', [
-, require('fh-wfm-sync')
+, require('raincatcher-sync')
 ...
 ])
 ```
@@ -39,20 +39,20 @@ syncService.manage(config.datasetId, null, queryParams);
 
 ```
 
-Checkout a full example [here](https://github.com/feedhenry-staff/wfm-workorder/blob/master/lib/angular/sync-service.js)
+Checkout a full example [here](https://github.com/feedhenry-raincatcher/raincatcher-workorder/blob/master/lib/angular/sync-service.js)
 
 
 ## Usage in an express backend
 
 ### Setup
 
-The server-side component of this WFM module exports a function that takes express and mediator instances as parameters, as in:
+The server-side component of this Raincatcher module exports a function that takes express and mediator instances as parameters, as in:
 
 ```javascript
 
 
 var _ = require('lodash')
-  , sync = require('fh-wfm-sync/lib/server')
+  , sync = require('raincatcher-sync/lib/server')
   , config = require('./config')
 
 
@@ -63,7 +63,7 @@ module.exports = function(mediator, app, mbaasApi) {
 ```
 #### Sync config options
 
-Check a complete example [here](https://github.com/feedhenry-staff/wfm-workorder/blob/master/lib/config.js)
+Check a complete example [here](https://github.com/feedhenry-raincatcher/raincatcher-workorder/blob/master/lib/config.js)
 
 ```javascript
 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "fh-wfm-sync",
+  "name": "raincatcher-sync",
   "version": "0.0.12",
-  "description": "An sync module for WFM",
+  "description": "An sync module for Raincatcher",
   "main": "lib/angular/sync-ng.js",
   "scripts": {
     "test-watch": "mochify --watch test/client/**/*.spec.js",
@@ -14,7 +14,7 @@
     "grunt-eslint": "grunt eslint"
   },
   "keywords": [
-    "wfm",
+    "raincatcher",
     "sync"
   ],
   "author": "Sebastien Blanc, Brian Leathem",


### PR DESCRIPTION
Motivation:
Currently this project's module name is named after the old Work Force
Management (WFM) which has changed to Raincatcher. But the npm module
names have not been updated which is that this commit does.

Modifications:
Updated the module name in package.json and updated README.md to reflect
the module change.

JIRA:
https://issues.jboss.org/browse/RAINCATCH-230
