### PR TITLE
Added a call to $fh.sync.getUID to get the most up-to-date UID

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,37 @@ function formatError(code, msg) {
   return error;
 }
 
+/**
+ * Function to check whether a notifcation from the $fh.sync API is relevant.
+ * @param {object} notification            - a $fh.sync Notifcation
+ * @param {object} comparison              - a comparison notification object
+ * @param {string} comparison.code         - The $fh.sync notification code that is relevant
+ * @param {string} comparison.message      - The $fh.sync notification message that is relevant
+ * @param {string} comparison.uid          - A Unique identifier for the synchronised document
+ * @returns {boolean}
+ */
+function isNotificationRelevant(notification, comparison) {
+
+  //The cached UID of the object may have changed in the sync framework from an update from the server.
+  //This updated uid is used for document notifications
+  //This call ensure that the correct document uid is used.
+  comparison.uid = $fh.sync && $fh.sync.getUID ? $fh.sync.getUID(comparison.uid) : comparison.uid;
+
+  if (comparison.code && notification.code !== comparison.code) {
+    return false;
+  }
+
+  if (comparison.message && notification.message !== comparison.message) {
+    return false;
+  }
+
+  if (comparison.uid && notification.uid !== comparison.uid) {
+    return false;
+  }
+
+  return true;
+}
+
 function init(_$fh, _syncOptions) {
   if (initialized) {
     console.log('sync-client already initalized.');
@@ -97,9 +128,10 @@ DataManager.prototype.create = function(object) {
   $fh.sync.doCreate(self.datasetId, object, function(msg) {
     // success
     self.stream.filter(function(notification) {
-      return notification.code === 'local_update_applied'
-        && notification.message === 'create'
-        ; // && notification.uid == object._localuid;  TODO: get the sync framework to include the temporary uid in the notification
+      return isNotificationRelevant(notification, {
+        code: 'local_update_applied',
+        message: 'create'
+      });
     }).take(1).toPromise(q.Promise)
     .then(function() {
       object._localuid = msg.uid;
@@ -146,9 +178,11 @@ DataManager.prototype.update = function(object) {
     $fh.sync.doUpdate(self.datasetId, uid, object, function() {
     // success
       self.stream.filter(function(notification) {
-        return notification.code === 'local_update_applied'
-        && notification.message === 'update'
-        && notification.uid === uid;
+        return isNotificationRelevant(notification, {
+          code: 'local_update_applied',
+          messag: 'update',
+          uid: uid
+        });
       }).take(1).toPromise(q.Promise)
     .then(function() {
       return self.read(uid);
@@ -173,9 +207,11 @@ DataManager.prototype.delete = function(object) {
     // success
     var uid = String(object.id);
     self.stream.filter(function(notification) {
-      return notification.code === 'local_update_applied'
-        && notification.message === 'delete'
-        && String(notification.uid) === uid;
+      return isNotificationRelevant(notification, {
+        code: 'local_update_applied',
+        message: 'delete',
+        uid: uid
+      });
     }).take(1).toPromise(q.Promise)
     .then(function(notification) {
       deferred.resolve(notification.message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.host.url=https://sonarqube.com
 sonar.projectKey=raincatcher-sync
 sonar.projectName=raincatcher-sync
-sonar.projectVersion=0.0.12
+sonar.projectVersion=0.0.13
 
 sonar.sources=./lib
 sonar.language=js


### PR DESCRIPTION
# Motiviation

When checking for relevant notifications, the $fh.sync framework can have an updated unique identifier that does not match the cached one.

# Changes

- Added a call to `$fh.sync.getUID` when checking UIDs of sync notifications.
- Add a function to test if sync notifications are relevant .