### PR TITLE
Raincatch 210 - build errors on a mac when installing raincatcher locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.0.15-alpha.1",
+  "version": "0.0.14",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.0.14",
+  "version": "0.0.15-alpha.1",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "cors": "2.7.1",
     "dotenv": "2.0.0",
     "express": "4.13.4",
-    "fh-mbaas-api": "5.13.1",
+    "fh-mbaas-api": "5.14.2",
     "fh-wfm-mediator": "0.0.15",
     "grunt": "^1.0.1",
     "grunt-eslint": "^18.0.0",


### PR DESCRIPTION
# Issue
Getting node-gyp build errors on a mac when installing raincatcher locally
Caused by dtrace-provider version used in older version of bunyan in `fh-mbaas-client`which was updated in latest `fh-mbaas-api`
# Solution
Update `fh-mbaas-api` to 5.14.2


# JIRA
https://issues.jboss.org/browse/RAINCATCH-210