### PR TITLE
Adding Mediator Subscribers For Datasets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
         options: {
           reporter: 'Spec',
           logErrors: true,
-          timeout: 10000,
+          timeout: 1000,
           run: true
         }
       }

--- a/README.md
+++ b/README.md
@@ -8,20 +8,18 @@ This module makes uses the [$fh.sync Client](https://access.redhat.com/documenta
 
 ## Client-side usage
 
-### Client-side usage (via broswerify)
-
-#### Setup
+### Setup
 
 This module is packaged in a CommonJS format, exporting the name of the Angular namespace.  The module can be included in an angular.js as follows:
 
 ```javascript
-angular.module('app', [require('fh-wfm-sync')], function(sync){
+angular.module('app', [require('fh-wfm-sync')], function(syncService){
 // ...
 });
 ```
-#### Integration
+### Integration
 
-##### Angular service
+#### Angular service
 
 The sync service must first be initialized using the `syncService.init()`. Generally, the syncService will be injected into another Angular service (or in a config block) :
 
@@ -32,44 +30,444 @@ The sync service must first be initialized using the `syncService.init()`. Gener
 });
 ```
 
-Once initialized the syncService can manage multiple `dataset` using the following function:
+##### Managing Datasets
+
+Once initialized the syncService can manage multiple `datasets` using the following function:
 
 ```javascript
+
+var config = {
+  ...
+  datasetId: "workorders"
+  ...
+};
+
+var queryParams = {
+  //Optional object passed with dataset sync requests.
+};
 
 syncService.manage(config.datasetId, null, queryParams);
 
 ```
 
-Checkout a full example [here](https://github.com/feedhenry-staff/wfm-workorder/blob/master/lib/angular/sync-service.js)
+### Topic Unique Identifiers
+
+Each of the topics takes an `object` as a parameter. The `topicUid` parameter is an *optional* parameter used to allow the unique identifier to be appended to the `done` and `error` topics published.
+
+This allows for the scenario where a developer wishes to limit the response of the topic.
+
+E.g
+
+```javascript
+
+//Generate a random number / string
+var topicUid = Math.floor(Math.random() * 100000000);
+
+//Subscribing to the done state for the list topic.
+//The topicUid is appended to limit the response of the wfm:sync:datasetid:list topic to this subscriber
+mediator.subscribe("done:wfm:sync:datasetid:list:" + topicUid, function(arrayOfItems) {
+  ...
+  handleListSuccess(arrayOfItems);
+  ...
+});
+
+//Subscribing to the error state for the list topic.
+//The topicUid is appended to limit the response of the wfm:sync:datasetid:list topic to this subscriber
+mediator.subscribe("error:wfm:sync:datasetid:list:" + topicUid, function(error) {
+
+  handleError(error);
+
+});
+
+mediator.publish("wfm:sync:datasetid:list", {
+    topicUid: topicUid
+});
+
+```
+
+Developers may also wish to not include the `topicUid` parameter. This will mean that the `done` and `error` topics will not have any unique identifiers appended.
+
+This is useful if the developer wishes to have global subscribers to the topics. E.g. a global subscriber to the *done:wfm:sync:list* topic that handles the completion of the list topic.
 
 
-#### Topics
 
-The following topics are published by the client side of the application:
+### Dataset Topic Subscriptions
 
-##### Data Set Topics
+The `syncService.manage` function automatically subscribes to the following topics for a `dataset`. For a `dataset` with an ID `datasetid`, the following topics are published:
 
-The following topics are published by the module for each `dataset`. If the 
+#### wfm:sync:datasetid:create
 
-###### $fh.sync Client Notifications
+##### Description
+
+Creating a new item in the dataset.
+
+##### Example
+
+
+```javascript
+var parameters = {
+  itemToCreate: {
+    //A Valid JSON Object
+  },
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:sync:datasetid:create", parameters);
+```
+
+
+#### wfm:sync:datasetid:update
+
+##### Description
+
+Updating an existing item in the dataset.
+
+##### Example
+
+
+```javascript
+var datasetItemToUpdate = {
+  ...
+  ...
+}
+
+var parameters = {
+  itemToUpdate: {
+    //A Valid JSON Object
+  },
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+};
+
+mediator.publish("wfm:sync:datasetid:update", parameters);
+```
+
+#### wfm:sync:datasetid:remove
+
+##### Description
+
+Removing a single item from the dataset.
+
+##### Example
+
+
+```javascript
+
+var parameters = {
+  id: "idofdataitemtoremove",
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+};
+
+mediator.publish("wfm:sync:datasetid:remove", parameters);
+```
+
+
+#### wfm:sync:datasetid:list
+
+##### Description
+
+Listing all of the items in the dataset.
+
+##### Example
+
+
+```javascript
+
+var parameters = {
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+};
+
+mediator.publish("wfm:sync:datasetid:list", parameters);
+
+```
+
+#### wfm:sync:datasetid:start
+
+##### Description
+
+Start the synchronisation process from client to cloud for this dataset.
+
+##### Example
+
+
+```javascript
+var parameters = {
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+};
+
+mediator.publish("wfm:sync:datasetid:start", parameters);
+```
+
+#### wfm:sync:datasetid:stop
+
+##### Description
+
+Stop the synchronisation process from client to cloud for this dataset.
+
+##### Example
+
+
+```javascript
+var parameters = {
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+};
+
+mediator.publish("wfm:sync:datasetid:stop", parameters);
+```
+
+#### wfm:sync:datasetid:force_sync
+
+##### Description
+
+Force the synchronisation of client and cloud data for this dataset.
+
+##### Example
+
+
+```javascript
+var parameters = {
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+};
+
+mediator.publish("wfm:sync:datasetid:force_sync", parameters);
+```
+
+
+
+### Dataset Published Topics
+
+The following topics are published by the module for each `dataset`.
+
+Each of the topics will have the `topicUid` parameter appended to the topic if it is passed as a parameter when published. 
+
+See the [Topic Unique Identifiers](#topic-unique-identifiers) section for more details.
+
+#### done:wfm:sync:datasetid:create
+
+The item was created for a dataset with id `datasetid`.
+
+
+```javascript
+
+mediator.subscribe("done:wfm:sync:datasetid:create", function(createdItem) {
+  ...
+  /**
+  *
+  *  createdItem = {
+       ...
+       //A unique ID assigned to the data item created
+  *    _localuid: "localid"
+       ...
+  *  }
+  *
+  */
+  ...
+});
+ 
+```
+
+#### error:wfm:sync:datasetid:create
+
+An error occurred when creating an item.
+ 
+```javascript
+
+mediator.subscribe("error:wfm:sync:datasetid:create", function(error) {
+  ...
+  
+  console.log(error.message);
+  ...
+});
+ 
+```
+
+#### done:wfm:sync:datasetid:update
+
+An item for the dataset with ID `datasetid` was updated.
+
+```javascript
+
+mediator.subscribe("done:wfm:sync:datasetid:update", function(updatedItem) {
+  ...
+  /**
+  *
+  *  updatedItem = {
+  *    ...
+  *    ...
+  *  }
+  *
+  */
+  ...
+});
+ 
+```
+
+#### error:wfm:sync:datasetid:update
+
+An error occurred when updating an item for the dataset with ID `datasetid`.
+ 
+```javascript
+
+mediator.subscribe("error:wfm:sync:datasetid:update", function(error) {
+  ...
+  
+  console.log(error.message);
+  ...
+});
+ 
+```
+
+#### done:wfm:sync:datasetid:remove
+
+An item was removed from the dataset.
+
+```javascript
+
+mediator.subscribe("done:wfm:sync:datasetid:remove", function() {
+  ...
+  
+  ...
+});
+ 
+```
+
+#### error:wfm:sync:datasetid:remove
+
+An error occurred when removing an item from the dataset.
+ 
+```javascript
+
+mediator.subscribe("error:wfm:sync:datasetid:remove:datasetitemid", function(error) {
+  ...
+  
+  console.log(error.message);
+  ...
+});
+ 
+```
+
+#### done:wfm:sync:datasetid:list
+
+A list of items for a dataset with ID `datasetid` completed successfully.
+
+```javascript
+
+mediator.subscribe("done:wfm:sync:datasetid:list", function(listOfItems) {
+  ...
+  /**
+  *
+  *  listOfItems = [{
+  *    ...
+  *    ...
+  *  }, {
+  *     ...
+  *     ...
+  *   }]
+  *
+  */
+  ...
+});
+ 
+```
+
+#### error:wfm:sync:datasetid:list
+
+An error occurred when listing items for a dataset with ID `datasetid`
+ 
+```javascript
+
+mediator.subscribe("error:wfm:sync:datasetid:list", function(error) {
+  ...
+  
+  console.log(error.message);
+  ...
+});
+ 
+```
+
+#### done:wfm:sync:datasetid:start
+
+The client-cloud sync process for a dataset with ID `datasetid` started successfully.
+
+```javascript
+
+mediator.subscribe("done:wfm:sync:datasetid:start", function() {
+  ...
+  ...
+});
+ 
+```
+
+#### error:wfm:sync:datasetid:start
+
+An error occurred when starting the client cloud sync process for a dataset with ID `datasetid`
+ 
+```javascript
+
+mediator.subscribe("error:wfm:sync:datasetid:start", function(error) {
+  ...
+  
+  console.log(error.message);
+  ...
+});
+ 
+```
+
+#### done:wfm:sync:datasetid:stop
+
+The client-cloud sync process for a dataset with ID `datasetid` stopped successfully.
+
+```javascript
+
+mediator.subscribe("done:wfm:sync:datasetid:stop", function() {
+  ...
+  ...
+});
+ 
+```
+
+#### error:wfm:sync:datasetid:stop
+
+An error occurred when stopping the client cloud sync process for a dataset with ID `datasetid`
+ 
+```javascript
+
+mediator.subscribe("error:wfm:sync:datasetid:stop", function(error) {
+  ...
+  
+  console.log(error.message);
+  ...
+});
+ 
+```
+
+#### Notification Topics
 
 The module publishes topics covering all of the notification codes available to the $fh.sync Client API.
 
-wfm:sync:**sync_notification_code**:**datasetId**
-
 The list of notification codes published are:
 
-* client_storage_failed: Loading or saving to client storage failed. This is a critical error and the Sync Client will not work properly without client storage.
-* sync_started: A synchronization cycle with the server has been started.
-* sync_complete: A synchronization cycle with the server has been completed.
-* offline_update: An attempt was made to update or delete a record while offline.
-* collision_detected: Update failed due to data collision.
-* remote_update_failed: Update failed for a reason other than data collision.
-* remote_update_applied: An update was applied to the remote data store.
-* local_update_applied: An update was applied to the local data store.
-* delta_received: A change was received from the remote data store for the dataset. It is best to listen to this notification and update the UI accordingly.
-* record_delta_received: A delta was received from the remote data store for the record. It is best to listen to this notification and update UI accordingly.
-* sync_failed: Synchronization loop failed to complete.
+
+| Topic         | Description           |
+| ------------- |:-------------:| 
+| wfm:sync:datasetid:client_storage_failed  | Loading or saving to client storage failed. This is a critical error and the Sync Client will not work properly without client storage. |
+| wfm:sync:datasetid:sync_started  | A synchronization cycle with the server has been started. |
+| wfm:sync:datasetid:sync_complete  | A synchronization cycle with the server has been completed. |
+| wfm:sync:datasetid:offline_update  | An attempt was made to update or delete a record while offline. |
+| wfm:sync:datasetid:collision_detected  |  Update failed due to data collision. |
+| wfm:sync:datasetid:remote_update_failed  | Update failed for a reason other than data collision. |
+| wfm:sync:datasetid:remote_update_applied  | An update was applied to the remote data store. |
+| wfm:sync:datasetid:local_update_applied  | An update was applied to the local data store. |
+| wfm:sync:datasetid:delta_received  | A change was received from the remote data store for the dataset. |
+| wfm:sync:datasetid:sync_failed  | Synchronization loop failed to complete. |
+
+##### Topic Parameters
 
 Each of these topics will be published with an object describing the event:
 

--- a/lib/angular/sync-ng.js
+++ b/lib/angular/sync-ng.js
@@ -21,19 +21,35 @@ angular.module('wfm.sync.service', [])
     });
   }
 
-  syncService.init = function($fh, syncOptions) {
-    $fh = $fh || {};
+  /**
+   *
+   * Initialising the sync module with any required options.
+   *
+   * @param {object} _$fh          - (Optional) A reference to the feedhenry client API
+   * @param {object} _syncOptions  - (Optional) Any options required for intialising the $fh.sync API.
+   */
+  syncService.init = function(_$fh, _syncOptions) {
+    var fhApi = (_$fh && _syncOptions) ? _$fh : window.$fh;
+    var syncOptions = (_$fh && _syncOptions) ? _syncOptions : _$fh;
     syncOptions = syncOptions || {};
 
-    //If the feedhenry API is passed, use this.
-    //Otherwise default to the global window.$fh
-    if ($fh.sync) {
-      sync.init($fh, syncOptions, mediator);
-    } else {
-      sync.init(window.$fh, syncOptions, mediator);
+
+    //If the feedhenry API is passed, initialise the sync module
+    if (fhApi && fhApi.sync) {
+      sync.init(fhApi, syncOptions, mediator);
     }
   };
 
+  /**
+   *
+   * Creating a manager for a single data set.
+   *
+   * @param {string} datasetId - The identifier for the dataset to manage
+   * @param {object} options   - Any sync options required for this data set. See $fh.sync Client API docs for more information.
+   * @param {object} queryParams - Parameters to pass when listing dataset items
+   * @param {object} metaData    - Metadata to pass to the server for synchronisation calls
+   * @returns {Promise<TResult>}
+   */
   syncService.manage = function(datasetId, options, queryParams, metaData) {
     return $q.when(sync.manage(datasetId, options, queryParams, metaData))
     .then(function(_manager) {

--- a/lib/client/client-spec.js
+++ b/lib/client/client-spec.js
@@ -65,9 +65,11 @@ describe("Raincatcher Sync Client Initialisation", function() {
 
   it("should create a new data manager when managing a new data set", function() {
     var self = this;
-    return syncClient.manage(mockDataSetId, mockSyncOptions, mockDataSetFilterParams, mockDataSetMetadataParams).then(function() {
+    return syncClient.manage(mockDataSetId, mockSyncOptions, mockDataSetFilterParams, mockDataSetMetadataParams).then(function(datasetManager) {
       sinon.assert.calledOnce(self.mock$fh.sync.manage);
       sinon.assert.calledWith(self.mock$fh.sync.manage, sinon.match(mockDataSetId), sinon.match(mockSyncOptions), sinon.match(mockDataSetFilterParams), sinon.match(mockDataSetMetadataParams));
+
+      datasetManager.removeSyncDataTopicSubscribers();
     });
   });
 

--- a/lib/client/data-manager-spec.js
+++ b/lib/client/data-manager-spec.js
@@ -10,6 +10,7 @@ var expect = chai.expect;
 describe("Data Manager", function() {
 
   var mockDataSetId = "mockdatasetid";
+  var dataManager;
 
   beforeEach(function() {
     var self = this;
@@ -19,10 +20,16 @@ describe("Data Manager", function() {
     };
   });
 
+
+  afterEach(function() {
+    dataManager.removeSyncDataTopicSubscribers();
+  });
+
+
   it("should initialise with a mediator", function() {
     var mock$fh = {};
 
-    var dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+    dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
 
     sinon.assert.calledOnce(this.mockDataSetNotificationObservableStream.forEach);
 
@@ -35,7 +42,7 @@ describe("Data Manager", function() {
   it("should initialise without a mediator", function() {
     var mock$fh = {};
 
-    var dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream);
+    dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream);
 
     //It should not have attached a `forEach` filter to the observable stream if there is no mediator
     sinon.assert.notCalled(this.mockDataSetNotificationObservableStream.forEach);
@@ -66,7 +73,7 @@ describe("Data Manager", function() {
         }
       };
 
-      var dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+      dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
 
       return dataManager.list().then(function(dataSetList) {
 
@@ -99,7 +106,7 @@ describe("Data Manager", function() {
         }
       };
 
-      var dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+      dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
 
       dataManager.create(mockDataItem).then(function(createResult) {
         expect(createResult).to.deep.equal(expectedCreatedData);
@@ -134,7 +141,7 @@ describe("Data Manager", function() {
       };
 
 
-      var dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+      dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
 
       return dataManager.read(mockRecordUid).then(function(readRecord) {
         expect(readRecord).to.deep.equal(mockDataItem);
@@ -170,7 +177,7 @@ describe("Data Manager", function() {
         }
       };
 
-      var dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+      dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
 
       return dataManager.update(mockDataItem).then(function(createResult) {
         expect(createResult).to.deep.equal(expectedCreatedData);
@@ -198,7 +205,7 @@ describe("Data Manager", function() {
         }
       };
 
-      var dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+      dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
 
       return dataManager.delete(mockDataItem).then(function() {
 
@@ -211,7 +218,7 @@ describe("Data Manager", function() {
   it("should publish topics from the data set notification stream", function() {
     var self = this;
     var mockSyncNotification = {
-      code: 'syn_notification_code',
+      code: 'sync_notification_code',
       message: "Sync Notification Message"
     };
 
@@ -224,9 +231,9 @@ describe("Data Manager", function() {
 
     var syncNotificationSubscriber = sinon.spy();
 
-    mediator.subscribe('wfm:sync:syn_notification_code:' + mockDataSetId, syncNotificationSubscriber);
+    mediator.subscribe('wfm:sync:mockdatasetid:sync_notification_code', syncNotificationSubscriber);
 
-    new DataManager(mockDataSetId, mock$fh, syncNotificationStream, mediator);
+    dataManager = new DataManager(mockDataSetId, mock$fh, syncNotificationStream, mediator);
 
     sinon.assert.notCalled(syncNotificationSubscriber);
 

--- a/lib/client/data-manager.js
+++ b/lib/client/data-manager.js
@@ -1,5 +1,7 @@
 var _ = require('lodash')
   , q = require('q');
+var mediatorManager = require('./mediator-subscribers');
+
 
 /**
  *
@@ -66,32 +68,40 @@ function DataManager(datasetId, $fh, dataSetNotificationStream, mediator) {
   this.$fh = $fh;
   this.stream = dataSetNotificationStream;
   this.mediator = mediator;
+  this.subscribers = {};
 
-  this.subscribeToSyncEvents();
+  this.createSyncDataTopicSubscribers();
 }
 
 /**
- * Subscribing to notifications for this data set from the $fh.sync Client API
- *
- * For more information on the
- *
+ * Creating all of the mediator subscribers for this sync data set.
  */
-DataManager.prototype.subscribeToSyncEvents = function subscribeToSyncEvents() {
+DataManager.prototype.createSyncDataTopicSubscribers = function createSyncDataTopicSubscribers() {
   var self = this;
 
-  //If there is no mediator applied, then we can't publish sync notification topics.
+  //If there is no mediator applied, then we can't subscribe to mediator topics.
   if (!self.mediator) {
     return;
   }
 
-
-  //For each remote error, publish a sync error topic
-  //This can be subscribed to by other modules. (Generally the module that created the manager)
-  self.stream.forEach(function(notification) {
-    var code = notification.code;
-    self.mediator.publish('wfm:sync:' + code + ':' + self.datasetId, notification);
-  });
+  self.SyncSubscribers = mediatorManager.init(self.mediator, self, {datasetId: self.datasetId});
 };
+
+/**
+ *
+ * Removing any subscribers associated with this data set.
+ *
+ */
+DataManager.prototype.removeSyncDataTopicSubscribers = function removeSyncDataTopicSubscribers() {
+  var self = this;
+
+  if (!self.mediator) {
+    return;
+  }
+
+  mediatorManager.tearDown(self.datasetId);
+};
+
 
 /**
  *
@@ -180,7 +190,13 @@ DataManager.prototype.create = function(itemToCreate) {
     });
   }
 
-  //Handling an error returned by the doCreate API call
+  /**
+   *
+   * Handling an error returned by the doCreate API call
+   *
+   * @param errorCode
+   * @param syncErrorMessage
+   */
   function handleCreateError(errorCode, syncErrorMessage) {
     deferred.reject(new Error(formatSyncErrorMessage(errorCode, syncErrorMessage)));
   }

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -11,7 +11,7 @@ var $fh,
   initialized = false,
   syncNotificationStream,
   syncNotifyListeners = [],
-  mediator;
+  mediator, dataSetManagerPromises = {};
 
 /**
  *
@@ -100,6 +100,14 @@ function manage(datasetId, options, queryParams, metaData) {
     return deferred.promise;
   }
 
+  //If there is already a manager initialising for this dataset, return the promise.
+  if (dataSetManagerPromises[datasetId]) {
+    return dataSetManagerPromises[datasetId];
+  }
+
+  var deferredManagerDeferred = q.defer();
+  dataSetManagerPromises[datasetId] = deferredManagerDeferred.promise;
+
   //Using the $fh.sync API to manage a single data set with the passed parameters above.
   $fh.sync.manage(datasetId, options, queryParams, metaData, function() {
     //Creating another observable stream that is filtered by the ID of th data set created.
@@ -112,10 +120,10 @@ function manage(datasetId, options, queryParams, metaData) {
     //This is used to encapsulate all of the functionality available to a single data set (E.g. CRDUL operations for workorders).
     var manager = new DataManager(datasetId, $fh, dataSetNotificationStream, mediator);
 
-    deferred.resolve(manager);
+    deferredManagerDeferred.resolve(manager);
   });
 
-  return deferred.promise;
+  return dataSetManagerPromises[datasetId];
 }
 
 

--- a/lib/client/mediator-subscribers/create-spec.js
+++ b/lib/client/mediator-subscribers/create-spec.js
@@ -1,0 +1,147 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+var q = require('q');
+var shortid = require('shortid');
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Sync Create Mediator Topic", function() {
+  var createTopic = "wfm:sync:mockdatasetid:create";
+
+  var mockDataToCreate = {
+    name: "This is a mock data item"
+  };
+
+  var mockDatasetId = "mockdatasetid";
+
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+  describe("Create Dataset Item", function() {
+
+    describe("Handling A Successful Creation", function() {
+
+      var doneTopic = "done:wfm:sync:mockdatasetid:create";
+
+      var mockDatasetManager = {
+        datasetId: mockDatasetId,
+        create: sinon.stub().resolves(mockDataToCreate)
+      };
+
+      beforeEach(function() {
+        syncSubscribers.on(CONSTANTS.TOPICS.CREATE, require('./create')(syncSubscribers, mockDatasetManager));
+      });
+
+      //Verifying the mocks were called with the correct parameters.
+      function checkMocksCalled(createResult) {
+        expect(createResult).to.deep.equal(createResult);
+
+        sinon.assert.calledOnce(mockDatasetManager.create);
+        sinon.assert.calledWith(mockDatasetManager.create, sinon.match(mockDataToCreate));
+      }
+
+      beforeEach(function() {
+        mockDatasetManager.create.reset();
+      });
+
+
+      it("should handle no unique topic id", function() {
+        var testDeferred = q.defer();
+
+        this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+        mediator.publish(createTopic, {itemToCreate: mockDataToCreate});
+
+        return testDeferred.promise.then(checkMocksCalled);
+      });
+
+      it("should handle unique topic id", function() {
+        var testDeferred = q.defer();
+
+        var topicUid = shortid.generate();
+
+        this.subscribers[doneTopic] = mediator.subscribe(doneTopic + ":" + topicUid, testDeferred.resolve);
+
+        mediator.publish(createTopic, {
+          itemToCreate: mockDataToCreate,
+          topicUid: topicUid
+        });
+
+        return testDeferred.promise.then(checkMocksCalled);
+      });
+
+    });
+
+    describe("Handling the error case", function() {
+
+      var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+
+      var mockDatasetManager = {
+        datasetId: mockDatasetId,
+        create: sinon.stub().rejects(expectedTopicError)
+      };
+
+
+      function checkErrorMocksCalled(topicError) {
+        expect(topicError).to.deep.equal(expectedTopicError);
+
+        sinon.assert.calledOnce(mockDatasetManager.create);
+        sinon.assert.calledWith(mockDatasetManager.create, sinon.match(mockDataToCreate));
+      }
+
+      beforeEach(function() {
+        mockDatasetManager.create.reset();
+
+        syncSubscribers.on(CONSTANTS.TOPICS.CREATE, require('./create')(syncSubscribers, mockDatasetManager));
+      });
+
+      it("should handle no unique topic id", function() {
+        var testDeferred = q.defer();
+
+
+        var errorTopic = "error:wfm:sync:mockdatasetid:create";
+
+        this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+        mediator.publish(createTopic, {itemToCreate: mockDataToCreate});
+
+        return testDeferred.promise.then(checkErrorMocksCalled);
+      });
+
+      it("should handle a unique topic id", function() {
+        var testDeferred = q.defer();
+
+        var topicUid = shortid.generate();
+
+        var errorTopic = "error:wfm:sync:mockdatasetid:create:" + topicUid;
+
+        this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+        mediator.publish(createTopic, {
+          itemToCreate: mockDataToCreate,
+          topicUid: topicUid
+        });
+
+        return testDeferred.promise.then(checkErrorMocksCalled);
+      });
+
+    });
+
+  });
+});

--- a/lib/client/mediator-subscribers/create.js
+++ b/lib/client/mediator-subscribers/create.js
@@ -1,0 +1,44 @@
+var CONSTANTS = require('../../constants');
+
+
+/**
+ *
+ * Creating a subscriber to the create topic for a single data set.
+ *
+ * @param {object} syncDatasetTopics       - The sync topic subscribers for a data set.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the create topic
+ */
+module.exports = function subscribeToCreateTopic(syncDatasetTopics, datasetManager) {
+
+
+  /**
+   *
+   * Handler for the data sync create topic for this dataset.
+   *
+   * @param {object} parameters
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @param {object} parameters.itemToCreate - The item to create.
+   */
+  return function handleCreateTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var datasetItemToCreate = parameters.itemToCreate;
+
+    //Creating a data item for this dataset.
+    datasetManager.create(datasetItemToCreate).then(function(createdDatasetItem) {
+
+      //Item created successfully, publishing the success topic.
+      var creatDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(creatDoneTopic, createdDatasetItem);
+
+    }).catch(function(error) {
+
+      //An error occurred while trying to create a new item, publishing the error topic.
+      var errorCreateTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(errorCreateTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/force-sync-spec.js
+++ b/lib/client/mediator-subscribers/force-sync-spec.js
@@ -1,0 +1,123 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var chai = require('chai');
+var _ = require('lodash');
+var q = require('q');
+var shortid = require('shortid');
+var expect = chai.expect;
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var CONSTANTS = require('../../constants');
+
+describe("Sync Force Sync Mediator Topic", function() {
+  var forceSyncTopic = "wfm:sync:mockdatasetid:force_sync";
+
+  var mockDatasetId = "mockdatasetid";
+
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+
+  describe("No Error", function() {
+    var doneTopic = "done:wfm:sync:mockdatasetid:force_sync";
+    var mockDatasetManager = {
+      datasetId: mockDatasetId,
+      forceSync: sinon.stub().resolves()
+    };
+
+    function checkMocks() {
+      sinon.assert.calledOnce(mockDatasetManager.forceSync);
+    }
+
+    beforeEach(function() {
+      mockDatasetManager.forceSync.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.FORCE_SYNC, require('./force-sync')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(forceSyncTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+      var expectedTopic = doneTopic + ":" + topicUid;
+
+      this.subscribers[doneTopic] = mediator.subscribe(expectedTopic, testDeferred.resolve);
+
+      mediator.publish(forceSyncTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+  });
+
+  describe("Error Case", function() {
+    var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+    var errorTopic = "error:wfm:sync:mockdatasetid:force_sync";
+
+    var mockDatasetManager = {
+      datasetId: mockDatasetId,
+      forceSync: sinon.stub().rejects(expectedTopicError)
+    };
+
+    function checkMocks(topicError) {
+      expect(topicError).to.deep.equal(expectedTopicError);
+
+      sinon.assert.calledOnce(mockDatasetManager.forceSync);
+    }
+
+    beforeEach(function() {
+      mockDatasetManager.forceSync.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.FORCE_SYNC, require('./force-sync')(syncSubscribers, mockDatasetManager));
+    });
+
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+      mediator.publish(forceSyncTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+
+      var expectedErrorTopic = errorTopic + ":" + topicUid;
+
+      this.subscribers[errorTopic] = mediator.subscribe(expectedErrorTopic, testDeferred.resolve);
+
+      mediator.publish(forceSyncTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+});

--- a/lib/client/mediator-subscribers/force-sync.js
+++ b/lib/client/mediator-subscribers/force-sync.js
@@ -1,0 +1,38 @@
+var CONSTANTS = require('../../constants');
+
+
+/**
+ *
+ * Creating a subscriber to the force_sync topic for a single data set.
+ *
+ * @param {Mediator} syncDatasetTopics         -  The sync topic subscribers for a data set.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the force_sync topic
+ */
+module.exports = function subscribeToForceSyncTopic(syncDatasetTopics, datasetManager) {
+
+
+  /**
+   * Handling the force_sync topic for this dataset.
+   *
+   * @param {object} parameters
+   * @param {string/number} parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   */
+  return function handleForceSync(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    //Creating the item in the sync store
+    datasetManager.forceSync().then(function() {
+      var forceSyncDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(forceSyncDoneTopic);
+
+    }).catch(function(error) {
+
+      var forceSyncErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(forceSyncErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/force-sync.js
+++ b/lib/client/mediator-subscribers/force-sync.js
@@ -25,13 +25,10 @@ module.exports = function subscribeToForceSyncTopic(syncDatasetTopics, datasetMa
     //Creating the item in the sync store
     datasetManager.forceSync().then(function() {
       var forceSyncDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.DONE_PREFIX, parameters.topicUid);
-
       self.mediator.publish(forceSyncDoneTopic);
 
     }).catch(function(error) {
-
       var forceSyncErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
-
       self.mediator.publish(forceSyncErrorTopic, error);
     });
   };

--- a/lib/client/mediator-subscribers/index.js
+++ b/lib/client/mediator-subscribers/index.js
@@ -1,0 +1,65 @@
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+var topicHandlers = {
+  create: require('./create'),
+  update: require('./update'),
+  list: require('./list'),
+  read: require('./read'),
+  remove: require('./remove'),
+  force_sync: require('./force-sync'),
+  start: require('./start'),
+  stop: require('./stop')
+};
+
+var syncSubscribers = {};
+
+module.exports = {
+  /**
+   * Initialisation of all the topics that this module is interested in.
+   * @param {Mediator} mediator
+   * @param {DataManager} datasetManager - The individual Data Manager for a data set.
+   * @param {object}  options
+   * @param {string}  options.datasetId  - The identifier for the data set
+   * @returns {Topics|exports|module.exports|*}
+   */
+  init: function(mediator, datasetManager, options) {
+
+    var datasetSyncSubscribers = syncSubscribers[options.datasetId];
+    //If there is already a set of subscribers set up, then don't subscribe again.
+    if (datasetSyncSubscribers) {
+      return datasetSyncSubscribers;
+    }
+
+    datasetSyncSubscribers = syncSubscribers[options.datasetId] = new MediatorTopicUtility(mediator);
+    datasetSyncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(options.datasetId);
+
+    //Setting up subscribers to the workorder topics.
+    _.each(CONSTANTS.TOPICS, function(topicName) {
+      if (topicHandlers[topicName]) {
+        datasetSyncSubscribers.on(topicName, topicHandlers[topicName](datasetSyncSubscribers, datasetManager));
+      }
+    });
+
+    //For each remote error, publish a sync error topic
+    //This can be subscribed to by other modules. (Generally the module that created the manager)
+    datasetManager.stream.forEach(function(notification) {
+      var code = notification.code;
+      datasetSyncSubscribers.mediator.publish(datasetSyncSubscribers.getTopic(code), notification);
+    });
+
+    return datasetSyncSubscribers;
+  },
+  /**
+   * Removing any subscribers for a specific data set
+   * @param {string} datasetId - The identifier for the data set.
+   */
+  tearDown: function(datasetId) {
+    if (syncSubscribers && datasetId && syncSubscribers[datasetId]) {
+      syncSubscribers[datasetId].unsubscribeAll();
+      delete syncSubscribers[datasetId];
+    }
+  }
+};

--- a/lib/client/mediator-subscribers/list-spec.js
+++ b/lib/client/mediator-subscribers/list-spec.js
@@ -1,0 +1,133 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var chai = require('chai');
+var _ = require('lodash');
+var q = require('q');
+var shortid = require('shortid');
+var expect = chai.expect;
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var CONSTANTS = require('../../constants');
+
+
+describe("Sync List Mediator Topic", function() {
+  var listTopic = "wfm:sync:mockdatasetid:list";
+  var mockDataItem = {
+    id: "mockdataitemid",
+    name: "This is a mock data item"
+  };
+
+  var mockDatasetId = "mockdatasetid";
+
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+  describe("No Error", function() {
+
+    var doneTopic = "done:wfm:sync:mockdatasetid:list";
+    var arrayOfDataItems = [mockDataItem];
+
+    var mockDatasetManager = {
+      datasetId: mockDatasetId,
+      list: sinon.stub().resolves(arrayOfDataItems)
+    };
+
+    function checkMocks(listResult) {
+      expect(listResult).to.deep.equal(arrayOfDataItems);
+
+      sinon.assert.calledOnce(mockDatasetManager.list);
+    }
+
+    beforeEach(function() {
+      mockDatasetManager.list.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.LIST, require('./list')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(listTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+
+      var expectedDoneTopic = doneTopic + ":" + topicUid;
+
+      this.subscribers[doneTopic] = mediator.subscribe(expectedDoneTopic, testDeferred.resolve);
+
+      mediator.publish(listTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+
+
+  describe("Error", function() {
+
+    var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+    var errorTopic = "error:wfm:sync:mockdatasetid:list";
+
+    var mockDatasetManager = {
+      datasetId: mockDatasetId,
+      list: sinon.stub().rejects(expectedTopicError)
+    };
+
+    beforeEach(function() {
+      mockDatasetManager.list.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.LIST, require('./list')(syncSubscribers, mockDatasetManager));
+    });
+
+    function checkMocks(topicError) {
+      expect(topicError).to.deep.equal(expectedTopicError);
+
+      sinon.assert.calledOnce(mockDatasetManager.list);
+    }
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+      this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+      mediator.publish(listTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid;
+      var expectedErrorTopic = errorTopic + ":" + topicUid;
+
+      this.subscribers[errorTopic] = mediator.subscribe(expectedErrorTopic, testDeferred.resolve);
+
+      mediator.publish(listTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+});

--- a/lib/client/mediator-subscribers/list.js
+++ b/lib/client/mediator-subscribers/list.js
@@ -1,0 +1,38 @@
+var CONSTANTS = require('../../constants');
+
+
+/**
+ *
+ * Creating a subscriber to the list topic for a single data set.
+ *
+ * @param {Mediator} syncDatasetTopics         - The sync topic subscribers for a data set.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the list topic
+ */
+module.exports = function subscribeToListTopic(syncDatasetTopics, datasetManager) {
+
+  /**
+   * Handling the list topic for this dataset.
+   *
+   * @param parameters
+   * @param parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   */
+  return function handleListTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    //Creating the item in the sync store
+    datasetManager.list().then(function(arrayOfDatasetItems) {
+      var listDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(listDoneTopic, arrayOfDatasetItems);
+
+    }).catch(function(error) {
+
+      var listErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(listErrorTopic, error);
+    });
+  };
+
+};

--- a/lib/client/mediator-subscribers/read-spec.js
+++ b/lib/client/mediator-subscribers/read-spec.js
@@ -1,0 +1,142 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var chai = require('chai');
+var _ = require('lodash');
+var q = require('q');
+var expect = chai.expect;
+var shortid = require('shortid');
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var CONSTANTS = require('../../constants');
+
+
+describe("Sync Read Mediator Topic", function() {
+  var readTopic = "wfm:sync:mockdatasetid:read";
+
+  var mockDataItem = {
+    id: "mockdataitemid",
+    name: "This is a mock data item"
+  };
+
+  var mockDatasetId = "mockdatasetid";
+
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+  describe("No Error", function() {
+    var doneTopic = "done:wfm:sync:mockdatasetid:read";
+
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      read: sinon.stub().resolves(mockDataItem)
+    };
+
+    function checkMocks(readResult) {
+      expect(readResult).to.deep.equal(mockDataItem);
+
+      sinon.assert.calledOnce(mockDatasetManager.read);
+      sinon.assert.calledWith(mockDatasetManager.read, sinon.match(mockDataItem.id));
+    }
+
+
+    beforeEach(function() {
+      mockDatasetManager.read.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.READ, require('./read')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+      var expectedDoneTopic = doneTopic + ":" + topicUid;
+
+      this.subscribers[doneTopic] = mediator.subscribe(expectedDoneTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id,
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+
+
+  describe("Error", function() {
+    var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+    var errorTopic = "error:wfm:sync:mockdatasetid:read";
+
+    function checkMocks(topicError) {
+      expect(topicError).to.deep.equal(expectedTopicError);
+
+      sinon.assert.calledOnce(mockDatasetManager.read);
+      sinon.assert.calledWith(mockDatasetManager.read, sinon.match(mockDataItem.id));
+    }
+
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      read: sinon.stub().rejects(expectedTopicError)
+    };
+
+    beforeEach(function() {
+      mockDatasetManager.read.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.READ, require('./read')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+      var expectedErrorTopic = errorTopic + ":" + topicUid;
+
+      this.subscribers[errorTopic] = mediator.subscribe(expectedErrorTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id,
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+
+
+});

--- a/lib/client/mediator-subscribers/read.js
+++ b/lib/client/mediator-subscribers/read.js
@@ -1,0 +1,39 @@
+var CONSTANTS = require('../../constants');
+
+
+/**
+ *
+ * Creating a subscriber to the read topic for a single data set.
+ *
+ * @param {Mediator} syncDatasetTopics         - The sync topic subscribers for a data set.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the read topic
+ */
+module.exports = function subscribeToReadTopic(syncDatasetTopics, datasetManager) {
+
+
+  /**
+   * Handling the read topic for this dataset.
+   *
+   * @param parameters
+   * @param parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @param parameters.id        - The ID of the item to read
+   */
+  return function handleReadTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    //Creating the item in the sync store
+    datasetManager.read(parameters.id).then(function(itemRead) {
+      var readDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(readDoneTopic, itemRead);
+
+    }).catch(function(error) {
+
+      var readErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(readErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/remove-spec.js
+++ b/lib/client/mediator-subscribers/remove-spec.js
@@ -1,0 +1,136 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var _ = require('lodash');
+var q = require('q');
+var shortid = require('shortid');
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var CONSTANTS = require('../../constants');
+
+describe("Sync Remove Mediator Topic", function() {
+  var readTopic = "wfm:sync:mockdatasetid:remove";
+
+  var mockDataItem = {
+    id: "mockdataitemid",
+    name: "This is a mock data item"
+  };
+
+  var mockDatasetId = "mockdatasetid";
+
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+  describe("No Error", function() {
+    var doneTopic = "done:wfm:sync:mockdatasetid:remove";
+
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      delete: sinon.stub().resolves()
+    };
+
+    function checkMocks() {
+
+      sinon.assert.calledOnce(mockDatasetManager.delete);
+      sinon.assert.calledWith(mockDatasetManager.delete, sinon.match({id: mockDataItem.id}));
+    }
+
+
+    beforeEach(function() {
+      mockDatasetManager.delete.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.REMOVE, require('./remove')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+      var expectedDoneTopic = doneTopic + ":" + topicUid;
+
+      this.subscribers[doneTopic] = mediator.subscribe(expectedDoneTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id,
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+
+
+  describe("Error", function() {
+    var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+    var errorTopic = "error:wfm:sync:mockdatasetid:remove";
+
+    function checkMocks() {
+      sinon.assert.calledOnce(mockDatasetManager.delete);
+      sinon.assert.calledWith(mockDatasetManager.delete, sinon.match({id: mockDataItem.id}));
+    }
+
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      delete: sinon.stub().rejects(expectedTopicError)
+    };
+
+    beforeEach(function() {
+      mockDatasetManager.delete.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.REMOVE, require('./remove')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+      var expectedErrorTopic = errorTopic + ":" + topicUid;
+
+      this.subscribers[errorTopic] = mediator.subscribe(expectedErrorTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id,
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+
+
+});

--- a/lib/client/mediator-subscribers/remove.js
+++ b/lib/client/mediator-subscribers/remove.js
@@ -1,0 +1,37 @@
+var CONSTANTS = require('../../constants');
+
+
+/**
+ *
+ * Creating a subscriber to the remove topic for a single data set.
+ *
+ * @param {Mediator} syncDatasetTopics         - The sync topic subscribers for a data set.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the remove topic
+ */
+module.exports = function subscribeToRemoveTopic(syncDatasetTopics, datasetManager) {
+
+  /**
+   * Handling the remove topic for this dataset.
+   *
+   * @param parameters
+   * @param parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @param parameters.id        - The ID of the item to read
+   */
+  return function handleRemoveTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    datasetManager.delete({id: parameters.id}).then(function() {
+      var removeDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(removeDoneTopic);
+
+    }).catch(function(error) {
+
+      var removeErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(removeErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/start-spec.js
+++ b/lib/client/mediator-subscribers/start-spec.js
@@ -1,0 +1,123 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var chai = require('chai');
+var _ = require('lodash');
+var q = require('q');
+var shortid = require('shortid');
+var expect = chai.expect;
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var CONSTANTS = require('../../constants');
+
+describe("Start Sync Mediator Topic", function() {
+  var startSyncTopic = "wfm:sync:mockdatasetid:start";
+
+  var mockDatasetId = "mockdatasetid";
+
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+
+  describe("No Error", function() {
+    var doneTopic = "done:wfm:sync:mockdatasetid:start";
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      start: sinon.stub().resolves()
+    };
+
+    function checkMocks() {
+      sinon.assert.calledOnce(mockDatasetManager.start);
+    }
+
+    beforeEach(function() {
+      mockDatasetManager.start.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.START, require('./start')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(startSyncTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+      var expectedTopic = doneTopic + ":" + topicUid;
+
+      this.subscribers[doneTopic] = mediator.subscribe(expectedTopic, testDeferred.resolve);
+
+      mediator.publish(startSyncTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+  });
+
+  describe("Error Case", function() {
+    var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+    var errorTopic = "error:wfm:sync:mockdatasetid:start";
+
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      start: sinon.stub().rejects(expectedTopicError)
+    };
+
+    function checkMocks(topicError) {
+      expect(topicError).to.deep.equal(expectedTopicError);
+
+      sinon.assert.calledOnce(mockDatasetManager.start);
+    }
+
+    beforeEach(function() {
+      mockDatasetManager.start.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.START, require('./start')(syncSubscribers, mockDatasetManager));
+    });
+
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+      mediator.publish(startSyncTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+
+      var expectedErrorTopic = errorTopic + ":" + topicUid;
+
+      this.subscribers[errorTopic] = mediator.subscribe(expectedErrorTopic, testDeferred.resolve);
+
+      mediator.publish(startSyncTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+});

--- a/lib/client/mediator-subscribers/start.js
+++ b/lib/client/mediator-subscribers/start.js
@@ -1,0 +1,37 @@
+var CONSTANTS = require('../../constants');
+
+
+
+/**
+ *
+ * Creating a subscriber to the start topic for a single data set.
+ *
+ * @param {Mediator} syncDatasetTopics         - The mediator used for subscriptions.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the start topic
+ */
+module.exports = function subscribeToStartSyncTopic(syncDatasetTopics, datasetManager) {
+
+  /**
+   * Handling the start topic for this dataset.
+   *
+   * @param parameters
+   * @param parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   */
+  return function handleStartTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    datasetManager.start().then(function() {
+      var startDatasetSyncTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.START, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(startDatasetSyncTopic);
+
+    }).catch(function(error) {
+
+      var startDatasetSyncTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.START, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(startDatasetSyncTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/stop-spec.js
+++ b/lib/client/mediator-subscribers/stop-spec.js
@@ -1,0 +1,122 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var chai = require('chai');
+var _ = require('lodash');
+var q = require('q');
+var shortid = require('shortid');
+var expect = chai.expect;
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var CONSTANTS = require('../../constants');
+
+describe("Stop Sync Mediator Topic", function() {
+  var stopSyncTopic = "wfm:sync:mockdatasetid:stop";
+
+  var mockDatasetId = "mockdatasetid";
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+
+  describe("No Error", function() {
+    var doneTopic = "done:wfm:sync:mockdatasetid:stop";
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      stop: sinon.stub().resolves()
+    };
+
+    function checkMocks() {
+      sinon.assert.calledOnce(mockDatasetManager.stop);
+    }
+
+    beforeEach(function() {
+      mockDatasetManager.stop.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.STOP, require('./stop')(syncSubscribers, mockDatasetManager));
+    });
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(stopSyncTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+      var expectedTopic = doneTopic + ":" + topicUid;
+
+      this.subscribers[doneTopic] = mediator.subscribe(expectedTopic, testDeferred.resolve);
+
+      mediator.publish(stopSyncTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+  });
+
+  describe("Error Case", function() {
+    var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+    var errorTopic = "error:wfm:sync:mockdatasetid:stop";
+
+    var mockDatasetManager = {
+      datasetId: "mockdatasetid",
+      stop: sinon.stub().rejects(expectedTopicError)
+    };
+
+    function checkMocks(topicError) {
+      expect(topicError).to.deep.equal(expectedTopicError);
+
+      sinon.assert.calledOnce(mockDatasetManager.stop);
+    }
+
+    beforeEach(function() {
+      mockDatasetManager.stop.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.STOP, require('./stop')(syncSubscribers, mockDatasetManager));
+    });
+
+
+    it("should handle no unique topic id", function() {
+      var testDeferred = q.defer();
+
+      this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+      mediator.publish(stopSyncTopic);
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+    it("should handle a unique topic id", function() {
+      var testDeferred = q.defer();
+
+      var topicUid = shortid.generate();
+
+      var expectedErrorTopic = errorTopic + ":" + topicUid;
+
+      this.subscribers[errorTopic] = mediator.subscribe(expectedErrorTopic, testDeferred.resolve);
+
+      mediator.publish(stopSyncTopic, {
+        topicUid: topicUid
+      });
+
+      return testDeferred.promise.then(checkMocks);
+    });
+
+  });
+});

--- a/lib/client/mediator-subscribers/stop.js
+++ b/lib/client/mediator-subscribers/stop.js
@@ -1,0 +1,36 @@
+var CONSTANTS = require('../../constants');
+
+
+/**
+ *
+ * Creating a subscriber to the stop topic for a single data set.
+ *
+ * @param {Mediator} syncDatasetTopics         - The mediator used for subscriptions.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the stop topic
+ */
+module.exports = function subscribeToStartSyncTopic(syncDatasetTopics, datasetManager) {
+
+  /**
+   * Handling the stop topic for this dataset.
+   *
+   * @param parameters
+   * @param parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   */
+  return function handleStopTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    datasetManager.stop().then(function() {
+      var stopDatasetSyncTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.STOP, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(stopDatasetSyncTopic);
+
+    }).catch(function(error) {
+
+      var stopDatasetSyncTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.STOP, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(stopDatasetSyncTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/update-spec.js
+++ b/lib/client/mediator-subscribers/update-spec.js
@@ -1,0 +1,144 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var sinon = require('sinon');
+require("sinon-as-promised");
+var chai = require('chai');
+var _ = require('lodash');
+var expect = chai.expect;
+var q = require('q');
+var shortid = require('shortid');
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var CONSTANTS = require('../../constants');
+
+
+describe("Sync Update Mediator Topic", function() {
+  var updateTopic = "wfm:sync:mockdatasetid:update";
+
+  var mockDataToUpdate = {
+    name: "This is a mock data item"
+  };
+
+  var mockDatasetId = "mockdatasetid";
+
+  var syncSubscribers = new MediatorTopicUtility(mediator);
+  syncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(mockDatasetId);
+
+  beforeEach(function() {
+    this.subscribers = {};
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    syncSubscribers.unsubscribeAll();
+  });
+
+  describe("Update Dataset Item", function() {
+
+    describe("Handling A Successful Update", function() {
+
+      var doneTopic = "done:wfm:sync:mockdatasetid:update";
+
+      var mockDatasetManager = {
+        datasetId: "mockdatasetid",
+        update: sinon.stub().resolves(mockDataToUpdate)
+      };
+
+      //Verifying the mocks were called with the correct parameters.
+      function checkMocksCalled(updateResult) {
+        expect(updateResult).to.deep.equal(mockDataToUpdate);
+
+        sinon.assert.calledOnce(mockDatasetManager.update);
+        sinon.assert.calledWith(mockDatasetManager.update, sinon.match(mockDataToUpdate));
+      }
+
+      beforeEach(function() {
+        mockDatasetManager.update.reset();
+        syncSubscribers.on(CONSTANTS.TOPICS.UPDATE, require('./update')(syncSubscribers, mockDatasetManager));
+      });
+
+
+      it("should handle no unique topic id", function() {
+        var testDeferred = q.defer();
+
+        this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+        mediator.publish(updateTopic, {itemToUpdate: mockDataToUpdate});
+
+        return testDeferred.promise.then(checkMocksCalled);
+      });
+
+      it("should handle unique topic id", function() {
+        var testDeferred = q.defer();
+
+        var topicUid = shortid.generate();
+
+        this.subscribers[doneTopic] = mediator.subscribe(doneTopic + ":" + topicUid, testDeferred.resolve);
+
+        mediator.publish(updateTopic, {
+          itemToUpdate: mockDataToUpdate,
+          topicUid: topicUid
+        });
+
+        return testDeferred.promise.then(checkMocksCalled);
+      });
+
+    });
+
+    describe("Handling the error case", function() {
+
+      var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
+
+      var mockDatasetManager = {
+        datasetId: "mockdatasetid",
+        update: sinon.stub().rejects(expectedTopicError)
+      };
+
+      function checkErrorMocksCalled(topicError) {
+        expect(topicError).to.deep.equal(expectedTopicError);
+
+        sinon.assert.calledOnce(mockDatasetManager.update);
+        sinon.assert.calledWith(mockDatasetManager.update, sinon.match(mockDataToUpdate));
+      }
+
+      beforeEach(function() {
+        mockDatasetManager.update.reset();
+
+        syncSubscribers.on(CONSTANTS.TOPICS.UPDATE, require('./update')(syncSubscribers, mockDatasetManager));
+      });
+
+      it("should handle no unique topic id", function() {
+        var testDeferred = q.defer();
+
+
+        var errorTopic = "error:wfm:sync:mockdatasetid:update";
+
+        this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+        mediator.publish(updateTopic, {itemToUpdate: mockDataToUpdate});
+
+        return testDeferred.promise.then(checkErrorMocksCalled);
+      });
+
+      it("should handle a unique topic id", function() {
+        var testDeferred = q.defer();
+
+        var topicUid = shortid.generate();
+
+        var errorTopic = "error:wfm:sync:mockdatasetid:update:" + topicUid;
+
+        this.subscribers[errorTopic] = mediator.subscribe(errorTopic, testDeferred.resolve);
+
+        mediator.publish(updateTopic, {
+          itemToUpdate: mockDataToUpdate,
+          topicUid: topicUid
+        });
+
+        return testDeferred.promise.then(checkErrorMocksCalled);
+      });
+
+    });
+
+  });
+});

--- a/lib/client/mediator-subscribers/update.js
+++ b/lib/client/mediator-subscribers/update.js
@@ -1,0 +1,39 @@
+var CONSTANTS = require('../../constants');
+
+
+/**
+ *
+ * Creating a subscriber to the update topic for a single data set.
+ *
+ * @param {Mediator} syncDatasetTopics         - The mediator used for subscriptions.
+ * @param {DataManager} datasetManager   - The individual data set manager. This is where the business logic exists for
+ * @returns {Subscription} - The subscription for the update topic
+ */
+module.exports = function subscribeToUpdateTopic(syncDatasetTopics, datasetManager) {
+
+  /**
+   *
+   * Handling the update topic for this dataset.
+   *
+   * @param parameters
+   * @param parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @param parameters.itemToUpdate - The Dataset Item To Update
+   */
+  return function handleUpdateTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    //Creating the item in the sync store
+    datasetManager.update(parameters.itemToUpdate).then(function(updatedDataSetItem) {
+      var creatDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(creatDoneTopic, updatedDataSetItem);
+
+    }).catch(function(error) {
+
+      var errorCreateTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+      self.mediator.publish(errorCreateTopic, error);
+    });
+  };
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,16 @@
+module.exports = {
+  TOPIC_PREFIX: "wfm",
+  SYNC_TOPIC_PREFIX: "wfm:sync",
+  ERROR_PREFIX: "error",
+  DONE_PREFIX: "done",
+  TOPICS: {
+    CREATE: "create",
+    UPDATE: "update",
+    LIST: "list",
+    REMOVE: "remove",
+    READ: "read",
+    START: "start",
+    STOP: "stop",
+    FORCE_SYNC: "force_sync"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.0.16",
+  "version": "0.1.0-alpha.4",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "lodash": "4.7.0",
     "q": "1.4.1",
-    "rx": "4.1.0"
+    "rx": "4.1.0",
+    "fh-wfm-mediator": "0.2.0-0"
   },
   "devDependencies": {
     "angular": "1.5.3",
@@ -36,7 +37,6 @@
     "dotenv": "2.0.0",
     "express": "4.13.4",
     "fh-mbaas-api": "5.14.2",
-    "fh-wfm-mediator": "0.0.15",
     "grunt": "1.0.1",
     "grunt-cli": "1.2.0",
     "grunt-eslint": "18.0.0",
@@ -44,6 +44,7 @@
     "load-grunt-tasks": "3.5.2",
     "mocha": "3.2.0",
     "nodemon": "1.9.1",
+    "shortid": "^2.2.6",
     "should": "8.3.0",
     "sinon": "1.17.6",
     "sinon-as-promised": "4.0.2"


### PR DESCRIPTION
# Motivation

The raincatcher-sync module should be loosely coupled by using the mediator to publish and subscribe topics required to perform sync operations.

TODO: The `lib/angular/sync-ng` functionality will be removed in future releases when the dependent modules have moved to publish and subscribe to topics.

- raincatcher-workorder
- raincatcher-workflow
- raincatcher-result
- raincatcher-message

# Changes

- Added topic subscribers / publishers for all actions available to the raincatcher sync module
- Updated the README file to document all of the topics published by the client side of the module.