### PR TITLE
RAINCATCH-219 Added user-defined collision handlers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,70 +1,72 @@
 'use strict';
 
-var defaultConfig = require('./config')
-  , q = require('q')
-  ;
+var defaultConfig = require('./config');
+var q = require('q');
+var _ = require('lodash');
 
 function initSync(mediator, mbaasApi, datasetId, syncOptions) {
   syncOptions = syncOptions || defaultConfig.syncOptions;
 
   var dataListHandler = function(datasetId, queryParams, cb) {
-    mediator.request('wfm:cloud:'+datasetId+':list', queryParams, {uid: null, timeout: 5000})
-    .then(function(data) {
-      var syncData = {};
-      data.forEach(function(object) {
-        syncData[object.id] = object;
+    mediator.request('wfm:cloud:' + datasetId + ':list', queryParams, {uid: null, timeout: 5000})
+      .then(function(data) {
+        var syncData = {};
+        data.forEach(function(object) {
+          syncData[object.id] = object;
+        });
+        cb(null, syncData);
+      }, function(error) {
+        console.log('Sync error: init:', datasetId, error);
+        cb(error);
       });
-      cb(null, syncData);
-    }, function(error) {
-      console.log('Sync error: init:', datasetId, error);
-      cb(error);
-    });
   };
 
   var dataCreateHandler = function(datasetId, data, cb) {
     var ts = new Date().getTime();  // TODO: replace this with a proper uniqe (eg. a cuid)
-    mediator.request('wfm:cloud:'+datasetId+':create', [data, ts], {uid: ts})
-    .then(function(object) {
-      var res = {
-        "uid" : object.id,
-        "data" : object
-      };
-      cb(null, res);
-    }, function(error) {
-      console.log('Sync error: init:', datasetId, error);
-      cb(error);
-    });
+    mediator.request('wfm:cloud:' + datasetId + ':create', [data, ts], {uid: ts})
+      .then(function(object) {
+        var res = {
+          "uid": object.id,
+          "data": object
+        };
+        cb(null, res);
+      }, function(error) {
+        console.log('Sync error: init:', datasetId, error);
+        cb(error);
+      });
   };
 
   var dataSaveHandler = function(datasetId, uid, data, cb) {
-    mediator.request('wfm:cloud:'+datasetId+':update', data, {uid: uid})
-    .then(function(object) {
-      cb(null, object);
-    }, function(error) {
-      console.log('Sync error: init:', datasetId, error);
-      cb(error);
-    });
+    mediator.request('wfm:cloud:' + datasetId + ':update', data, {uid: uid})
+      .then(function(object) {
+        cb(null, object);
+      }, function(error) {
+        console.log('Sync error: init:', datasetId, error);
+        cb(error);
+      });
   };
 
   var dataGetHandler = function(datasetId, uid, cb) {
-    mediator.request('wfm:cloud:'+datasetId+':read', uid)
-    .then(function(object) {
-      cb(null, object);
-    }, function(error) {
-      console.log('Sync error: init:', datasetId, error);
-      cb(error);
-    });
+    mediator.request('wfm:cloud:' + datasetId + ':read', uid)
+      .then(function(object) {
+        cb(null, object);
+      }, function(error) {
+        console.log('Sync error: init:', datasetId, error);
+        cb(error);
+      });
   };
 
   var dataDeleteHandler = function(datasetId, uid, cb) {
-    mediator.request('wfm:cloud:'+datasetId+':delete', uid)
-    .then(function(message) {
-      cb(null, message);
-    }, function(error) {
-      console.log('Sync error: init:', datasetId, error);
-      cb(error);
-    });
+    mediator.request('wfm:cloud:' + datasetId + ':delete', uid)
+      .then(function(message) {
+        cb(null, message);
+      }, function(error) {
+        console.log('Sync error: init:', datasetId, error);
+        cb(error);
+      });
   };
+
+  var collisionHandler = syncOptions.dataCollisionHandler;
 
   //start the sync service
   var deferred = q.defer();
@@ -78,6 +80,11 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       mbaasApi.sync.handleUpdate(datasetId, dataSaveHandler);
       mbaasApi.sync.handleRead(datasetId, dataGetHandler);
       mbaasApi.sync.handleDelete(datasetId, dataDeleteHandler);
+
+      // set optional custom collision handler if its a function
+      if (_.isFunction(collisionHandler)) {
+        mbaasApi.sync.handleCollision(datasetId, collisionHandler);
+      }
       deferred.resolve(datasetId);
     }
   });
@@ -93,6 +100,6 @@ function stop(mbaasApi, datasetId) {
 }
 
 module.exports = {
-  init: initSync
-, stop: stop
+  init: initSync,
+  stop: stop
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.1",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "repository": {


### PR DESCRIPTION
# What
Developers should be able to add their own collision handlers for the raincatcher-sync module.

# How
allowed a custom handler to be added to sync options for a dataset, user fh-mbaas-api sync functionality to set custom collision handler

# Related PR
https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud/pull/65

# JIRA
https://issues.jboss.org/browse/RAINCATCH-219