### PR TITLE
RAINCATCH-708 Update sync data handlers with new method signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A sync module for FeedHenry WFM providing :
 
 This module makes uses the [$fh.sync Client](https://access.redhat.com/documentation/en/red-hat-mobile-application-platform-hosted/3/paged/client-api/chapter-11-fhsync) and [$fh.sync Cloud](https://access.redhat.com/documentation/en/red-hat-mobile-application-platform-hosted/3/paged/cloud-api/chapter-10-fhsync) APIs to provide the data synchronisation functionality.
 
+## Notice
+
+Version `1.x` of this module requires `fh-mbaas-api 7`. 
+Version `0.x` of this module supports older versions of `fh-mbaas-api`.
+
 ## Client-side usage
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module makes uses the [$fh.sync Client](https://access.redhat.com/documenta
 
 ## Notice
 
-Version `1.x` of this module requires `fh-mbaas-api 7`. 
+Version `1.x` of this module requires `fh-mbaas-api 7.x`. 
 Version `0.x` of this module supports older versions of `fh-mbaas-api`.
 
 ## Client-side usage

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,7 +13,6 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       .then(function(data) {
         var syncData = {};
         data.forEach(function(object) {
-          object._id = getObjectId(object);
           syncData[object.id] = object;
         });
         cb(null, syncData);
@@ -51,7 +50,6 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
   var dataGetHandler = function(datasetId, uid, metadata, cb) {
     mediator.request('wfm:cloud:' + datasetId + ':read', uid)
       .then(function(object) {
-        object._id = getObjectId(object);
         cb(null, object);
       }, function(error) {
         debug('Sync error: init:', datasetId, error);
@@ -98,19 +96,6 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
     }
   });
   return deferred.promise;
-}
-
-/**
- * If the objects _id field is a Mongodb~ObjectID, convert it to a string.
- *
- * @param {String|Object} object - The object to check.
- * @returns {String} - The original _id field or the converted Mongodb~ObjectID
- */
-function getObjectId(object) {
-  if (object._id && typeof object._id === 'object') {
-    return object._id.toHexString();
-  }
-  return object._id;
 }
 
 function stop(mbaasApi, datasetId) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,6 +13,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       .then(function(data) {
         var syncData = {};
         data.forEach(function(object) {
+          object._id = getObjectId(object);
           syncData[object.id] = object;
         });
         cb(null, syncData);
@@ -50,6 +51,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
   var dataGetHandler = function(datasetId, uid, metadata, cb) {
     mediator.request('wfm:cloud:' + datasetId + ':read', uid)
       .then(function(object) {
+        object._id = getObjectId(object);
         cb(null, object);
       }, function(error) {
         debug('Sync error: init:', datasetId, error);
@@ -96,6 +98,19 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
     }
   });
   return deferred.promise;
+}
+
+/**
+ * If the objects _id field is a Mongodb~ObjectID, convert it to a string.
+ *
+ * @param {String|Object} object - The object to check.
+ * @returns {String} - The original _id field or the converted Mongodb~ObjectID
+ */
+function getObjectId(object) {
+  if (object._id && typeof object._id === 'object') {
+    return object._id.toHexString();
+  }
+  return object._id;
 }
 
 function stop(mbaasApi, datasetId) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,7 @@ var debug = require('./utils/logger')(__filename);
 function initSync(mediator, mbaasApi, datasetId, syncOptions) {
   syncOptions = syncOptions || defaultConfig.syncOptions;
   debug('Sync init');
-  var dataListHandler = function(datasetId, queryParams, cb) {
+  var dataListHandler = function(datasetId, queryParams, metadata, cb) {
     mediator.request('wfm:cloud:' + datasetId + ':list', queryParams, {uid: null, timeout: 5000})
       .then(function(data) {
         var syncData = {};
@@ -22,7 +22,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       });
   };
 
-  var dataCreateHandler = function(datasetId, data, cb) {
+  var dataCreateHandler = function(datasetId, data, metadata, cb) {
     var ts = new Date().getTime();  // TODO: replace this with a proper uniqe (eg. a cuid)
     mediator.request('wfm:cloud:' + datasetId + ':create', [data, ts], {uid: ts})
       .then(function(object) {
@@ -37,7 +37,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       });
   };
 
-  var dataSaveHandler = function(datasetId, uid, data, cb) {
+  var dataSaveHandler = function(datasetId, uid, data, metadata, cb) {
     mediator.request('wfm:cloud:' + datasetId + ':update', data, {uid: uid})
       .then(function(object) {
         cb(null, object);
@@ -47,7 +47,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       });
   };
 
-  var dataGetHandler = function(datasetId, uid, cb) {
+  var dataGetHandler = function(datasetId, uid, metadata, cb) {
     mediator.request('wfm:cloud:' + datasetId + ':read', uid)
       .then(function(object) {
         cb(null, object);
@@ -57,7 +57,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       });
   };
 
-  var dataDeleteHandler = function(datasetId, uid, cb) {
+  var dataDeleteHandler = function(datasetId, uid, metadata, cb) {
     mediator.request('wfm:cloud:' + datasetId + ':delete', uid)
       .then(function(message) {
         cb(null, message);

--- a/lib/server.js
+++ b/lib/server.js
@@ -89,7 +89,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
 
       //Set optional custom hash function to deal with detecting model changes.
       if (_.isFunction(syncOptions.hashFunction)) {
-        mbaasApi.sync.handleHash(datasetId, syncOptions.hashFunction);
+        mbaasApi.sync.setRecordHashFn(datasetId, syncOptions.hashFunction);
       }
 
       deferred.resolve(datasetId);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rx": "4.1.0"
   },
   "peerDependencies": {
-    "fh-mbaas-api": "7.0.0-3"
+    "fh-mbaas-api": "^7.0.0"
   },
   "devDependencies": {
     "angular": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "q": "1.4.1",
     "rx": "4.1.0"
   },
+  "peerDependencies": {
+    "fh-mbaas-api": "7.0.0-3"
+  },
   "devDependencies": {
     "angular": "1.5.3",
     "angular-mocks": "1.5.3",
@@ -37,7 +40,6 @@
     "cors": "2.7.1",
     "dotenv": "2.0.0",
     "express": "4.13.4",
-    "fh-mbaas-api": "6.1.6",
     "grunt": "1.0.1",
     "grunt-cli": "1.2.0",
     "grunt-eslint": "18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "repository": {


### PR DESCRIPTION
In sync 7.x.x the method signatures for data handlers have changed.
This change updates the overridden data handlers to use these new
method signatures.

I'm not entirely sure where the `metadata` can be passed into the
mediator request or if it needs to be included, it wasn't before.

@grdryn @paolobueno Would you mind taking a look?