### PR TITLE
Added state handling to sync remote updates

### DIFF
--- a/lib/client/data-manager-spec.js
+++ b/lib/client/data-manager-spec.js
@@ -316,4 +316,40 @@ describe("Data Manager", function() {
 
   });
 
+  it("Should delete sync status for a data object if the event was a success notification", function() {
+    var mockOriginalMetaData = {
+      syncEvents: {
+        mockEventUID: 'mock failed to be deleted on success notification'
+      }
+    };
+
+    var mockEventData = {
+      uid: "mockEventUID",
+      code: "remote_update_applied",
+      message: {
+        type: "mockEventType",
+        msg: "mockEventMsg",
+        action: "mockEventAction"
+      }
+    };
+
+    var mock$fh = {
+      sync: {
+        getMetaData: sinon.stub().callsArgWith(1, mockOriginalMetaData),
+        setMetaData: sinon.stub().callsArgWith(2)
+      }
+    };
+
+    dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+
+
+    return dataManager.addEvent(mockEventData).then(function() {
+      assert(mock$fh.sync.getMetaData.calledOnce);
+      assert(mock$fh.sync.getMetaData.calledWith(sinon.match(mockDataSetId), sinon.match.func));
+      assert(mock$fh.sync.setMetaData.calledOnce);
+      expect(mockOriginalMetaData.syncEvents).to.be.empty;
+    });
+
+  });
+
 });

--- a/lib/client/data-manager-spec.js
+++ b/lib/client/data-manager-spec.js
@@ -244,4 +244,76 @@ describe("Data Manager", function() {
     sinon.assert.calledWith(syncNotificationSubscriber, mockSyncNotification);
   });
 
+  it("should add the sync status for a data object if the event was a failed notification", function() {
+    var mockOriginalMetaData = {};
+    var mockEventData = {
+      uid: "mockEventUID",
+      code: "remote_update_failed",
+      message: {
+        type: "mockEventType",
+        msg: "mockEventMsg",
+        action: "mockEventAction"
+      }
+    };
+    var mockNewMetaData = {
+      syncEvents: {
+        mockEventUID : {
+          entityId : mockEventData.uid,
+          code: mockEventData.code,
+          action: mockEventData.message.action,
+          message: mockEventData.message.msg,
+          type: mockEventData.message.type,
+          ts: sinon.match.number
+        }
+      }
+    };
+
+    var mock$fh = {
+      sync: {
+        getMetaData: sinon.stub().callsArgWith(1, mockOriginalMetaData),
+        setMetaData: sinon.stub().callsArgWith(2)
+      }
+    };
+
+    dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+
+    return dataManager.addEvent(mockEventData).then(function() {
+      assert(mock$fh.sync.getMetaData.calledOnce);
+      assert(mock$fh.sync.getMetaData.calledWith(sinon.match(mockDataSetId), sinon.match.func));
+      assert(mock$fh.sync.setMetaData.calledOnce);
+      assert(mock$fh.sync.setMetaData.calledWith(sinon.match(mockDataSetId), sinon.match(mockNewMetaData), sinon.match.func, sinon.match.func));
+    });
+
+  });
+
+  it("should not add the sync status for a data object if the event was a success notification", function() {
+    var mockOriginalMetaData = {};
+    var mockEventData = {
+      uid: "mockEventUID",
+      code: "remote_update_applied",
+      message: {
+        type: "mockEventType",
+        msg: "mockEventMsg",
+        action: "mockEventAction"
+      }
+    };
+
+    var mock$fh = {
+      sync: {
+        getMetaData: sinon.stub().callsArgWith(1, mockOriginalMetaData),
+        setMetaData: sinon.stub().callsArgWith(2)
+      }
+    };
+
+    dataManager = new DataManager(mockDataSetId, mock$fh, this.mockDataSetNotificationObservableStream, mediator);
+
+    return dataManager.addEvent(mockEventData).then(function() {
+      assert(mock$fh.sync.getMetaData.calledOnce);
+      assert(mock$fh.sync.getMetaData.calledWith(sinon.match(mockDataSetId), sinon.match.func));
+      assert(mock$fh.sync.setMetaData.calledOnce);
+      assert(mock$fh.sync.setMetaData.calledWith(sinon.match(mockDataSetId), sinon.match(mockOriginalMetaData), sinon.match.func, sinon.match.func));
+    });
+
+  });
+
 });

--- a/lib/client/data-manager.js
+++ b/lib/client/data-manager.js
@@ -80,14 +80,30 @@ function DataManager(datasetId, $fh, dataSetNotificationStream, mediator) {
  */
 DataManager.prototype.addEvent = function addEvent(event) {
   debug('addEvent', event);
+  if (event) {
+    return saveEventToMetaData(this, event);
+  } else {
+    debug('Invalid event object', event);
+  }
 
-  var self = this;
+
+};
+
+/**
+ * Saves an event to the metadata of the dataset managed by the passed in manager
+ * @param {Object} datamanager - datamanager to save the metadata for
+ * @param {Object} event - event to be saved in the metadata
+ * @returns {Promise}
+ */
+function saveEventToMetaData(datamanager, event) {
   var deferred = q.defer();
-  this.$fh.sync.getMetaData(this.datasetId, function(metadata) {
+  datamanager.$fh.sync.getMetaData(datamanager.datasetId, function(metadata) {
     metadata = metadata || {};
 
     metadata.syncEvents = metadata.syncEvents || {};
 
+    // We are only saving failed sync events otherwise clean up from the metadata.
+    // If there is no sync event for a given entity it means that the sync has been successful.
     if (event.code === CONSTANTS.SYNC_TOPICS.DATA.REMOTE_UPDATE_FAILED) {
       metadata.syncEvents[event.uid] = {
         entityId: event.uid,
@@ -103,12 +119,12 @@ DataManager.prototype.addEvent = function addEvent(event) {
       debug('Sync event successful, deleting fail status from metadata');
     }
 
-    self.$fh.sync.setMetaData(self.datasetId, metadata, deferred.resolve, deferred.reject);
+    datamanager.$fh.sync.setMetaData(datamanager.datasetId, metadata, deferred.resolve, deferred.reject);
 
   }, deferred.reject);
 
   return deferred.promise;
-};
+}
 
 /**
  * returns metadata for the dataset managed by this manager

--- a/lib/client/data-manager.js
+++ b/lib/client/data-manager.js
@@ -74,6 +74,37 @@ function DataManager(datasetId, $fh, dataSetNotificationStream, mediator) {
 }
 
 /**
+ * Sets sync status for a result object.
+ * @param {object} event - object passed in by sync event handler, should contain data used for logItem object.
+ */
+DataManager.prototype.addEvent = function addEvent(event) {
+  var self = this;
+  var deferred = q.defer();
+
+  console.log("addEvent", addEvent);
+
+  this.$fh.sync.getMetaData(this.datasetId, function(metadata) {
+    metadata = metadata || {};
+
+    metadata.syncEvents = metadata.syncEvents || {};
+
+    metadata.syncEvents[event.uid] = {
+      entityId: event.uid,
+      code: event.code,
+      action: event.message.action,
+      message: event.message.msg,
+      type: event.message.type,
+      ts: Date.now()
+    };
+
+    self.$fh.sync.setMetaData(self.datasetId, metadata, deferred.resolve, deferred.reject);
+
+  }, deferred.reject);
+
+  return deferred.promise;
+};
+
+/**
  * Creating all of the mediator subscribers for this sync data set.
  */
 DataManager.prototype.createSyncDataTopicSubscribers = function createSyncDataTopicSubscribers() {

--- a/lib/client/data-manager.js
+++ b/lib/client/data-manager.js
@@ -80,7 +80,6 @@ function DataManager(datasetId, $fh, dataSetNotificationStream, mediator) {
 DataManager.prototype.addEvent = function addEvent(event) {
   var self = this;
   var deferred = q.defer();
-
   this.$fh.sync.getMetaData(this.datasetId, function(metadata) {
     metadata = metadata || {};
 

--- a/lib/client/data-manager.js
+++ b/lib/client/data-manager.js
@@ -1,7 +1,8 @@
 var _ = require('lodash');
 var q = require('q');
 var mediatorManager = require('./mediator-subscribers');
-
+var debug = require('../utils/logger')(__filename);
+var CONSTANTS = require('../constants');
 
 /**
  *
@@ -74,10 +75,12 @@ function DataManager(datasetId, $fh, dataSetNotificationStream, mediator) {
 }
 
 /**
- * Sets sync status for a result object.
+ * Sets sync status for an object.
  * @param {object} event - object passed in by sync event handler, should contain data used for logItem object.
  */
 DataManager.prototype.addEvent = function addEvent(event) {
+  debug('addEvent', event);
+
   var self = this;
   var deferred = q.defer();
   this.$fh.sync.getMetaData(this.datasetId, function(metadata) {
@@ -85,14 +88,20 @@ DataManager.prototype.addEvent = function addEvent(event) {
 
     metadata.syncEvents = metadata.syncEvents || {};
 
-    metadata.syncEvents[event.uid] = {
-      entityId: event.uid,
-      code: event.code,
-      action: event.message.action,
-      message: event.message.msg,
-      type: event.message.type,
-      ts: Date.now()
-    };
+    if (event.code === CONSTANTS.SYNC_TOPICS.DATA.REMOTE_UPDATE_FAILED) {
+      metadata.syncEvents[event.uid] = {
+        entityId: event.uid,
+        code: event.code,
+        action: event.message.action,
+        message: event.message.msg,
+        type: event.message.type,
+        ts: Date.now()
+      };
+      debug('Added new failed event sync status to metadata', metadata.syncEvents[event.uid]);
+    } else {
+      delete metadata.syncEvents[event.uid];
+      debug('Sync event successful, deleting fail status from metadata');
+    }
 
     self.$fh.sync.setMetaData(self.datasetId, metadata, deferred.resolve, deferred.reject);
 
@@ -100,6 +109,17 @@ DataManager.prototype.addEvent = function addEvent(event) {
 
   return deferred.promise;
 };
+
+/**
+ * returns metadata for the dataset managed by this manager
+ * @param {function} callback - a callback that will get metadata passed in.
+ */
+DataManager.prototype.getMetaData = function getMetaData(callback) {
+  this.$fh.sync.getMetaData(this.datasetId, function(metadata) {
+    callback(metadata);
+  });
+};
+
 
 /**
  * Creating all of the mediator subscribers for this sync data set.

--- a/lib/client/data-manager.js
+++ b/lib/client/data-manager.js
@@ -1,5 +1,5 @@
-var _ = require('lodash')
-  , q = require('q');
+var _ = require('lodash');
+var q = require('q');
 var mediatorManager = require('./mediator-subscribers');
 
 
@@ -80,8 +80,6 @@ function DataManager(datasetId, $fh, dataSetNotificationStream, mediator) {
 DataManager.prototype.addEvent = function addEvent(event) {
   var self = this;
   var deferred = q.defer();
-
-  console.log("addEvent", addEvent);
 
   this.$fh.sync.getMetaData(this.datasetId, function(metadata) {
     metadata = metadata || {};

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -5,7 +5,7 @@ var _ = require('lodash')
   , defaultConfig = require('../config')
   , Rx = require('rx')
   , DataManager = require('./data-manager');
-
+var debug = require('../utils/logger')(__filename);
 
 var $fh,
   initialized = false,
@@ -40,6 +40,7 @@ function addListener(listener) {
  * @param _mediator - The mediator to use for publishing topics.
  */
 function init(_$fh, _syncOptions, _mediator) {
+  debug('Client init');
   if (initialized) {
     return;
   }

--- a/lib/client/mediator-subscribers/create.js
+++ b/lib/client/mediator-subscribers/create.js
@@ -24,7 +24,7 @@ module.exports = function subscribeToCreateTopic(syncDatasetTopics, datasetManag
     var self = this;
     parameters = parameters || {};
     var datasetItemToCreate = parameters.itemToCreate;
-
+    delete datasetItemToCreate._syncStatus;
     //Creating a data item for this dataset.
     datasetManager.create(datasetItemToCreate).then(function(createdDatasetItem) {
 

--- a/lib/client/mediator-subscribers/create.js
+++ b/lib/client/mediator-subscribers/create.js
@@ -24,7 +24,10 @@ module.exports = function subscribeToCreateTopic(syncDatasetTopics, datasetManag
     var self = this;
     parameters = parameters || {};
     var datasetItemToCreate = parameters.itemToCreate;
+
+    // remove _syncStatus, it can cause sync loop when updated and this data is irrelevant outside client
     delete datasetItemToCreate._syncStatus;
+
     //Creating a data item for this dataset.
     datasetManager.create(datasetItemToCreate).then(function(createdDatasetItem) {
 

--- a/lib/client/mediator-subscribers/index.js
+++ b/lib/client/mediator-subscribers/index.js
@@ -2,6 +2,7 @@ var _ = require('lodash');
 var CONSTANTS = require('../../constants');
 
 var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var syncEventHandler = require('./sync-events');
 
 var topicHandlers = {
   create: require('./create'),
@@ -41,6 +42,10 @@ module.exports = {
       if (topicHandlers[topicName]) {
         datasetSyncSubscribers.on(topicName, topicHandlers[topicName](datasetSyncSubscribers, datasetManager));
       }
+    });
+
+    _.each(CONSTANTS.SYNC_TOPICS, function(syncTopicName) {
+      datasetSyncSubscribers.on(syncTopicName, syncEventHandler(datasetManager));
     });
 
     //For each remote error, publish a sync error topic

--- a/lib/client/mediator-subscribers/index.js
+++ b/lib/client/mediator-subscribers/index.js
@@ -44,7 +44,7 @@ module.exports = {
       }
     });
 
-    _.each(CONSTANTS.SYNC_TOPICS, function(syncTopicName) {
+    _.each(CONSTANTS.SYNC_TOPICS.DATA, function(syncTopicName) {
       datasetSyncSubscribers.on(syncTopicName, syncEventHandler(datasetManager));
     });
 

--- a/lib/client/mediator-subscribers/list.js
+++ b/lib/client/mediator-subscribers/list.js
@@ -20,8 +20,9 @@ module.exports = function subscribeToListTopic(syncDatasetTopics, datasetManager
   return function handleListTopic(parameters) {
     var self = this;
     parameters = parameters || {};
-    //Creating the item in the sync store
-    datasetManager.$fh.sync.getMetaData(datasetManager.datasetId, function(metadata) {
+
+
+    datasetManager.getMetaData(function(metadata) {
       datasetManager.list().then(function(arrayOfDatasetItems) {
         var listDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX, parameters.topicUid);
 

--- a/lib/client/mediator-subscribers/list.js
+++ b/lib/client/mediator-subscribers/list.js
@@ -20,19 +20,24 @@ module.exports = function subscribeToListTopic(syncDatasetTopics, datasetManager
   return function handleListTopic(parameters) {
     var self = this;
     parameters = parameters || {};
-
     //Creating the item in the sync store
-    datasetManager.list().then(function(arrayOfDatasetItems) {
-      var listDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+    datasetManager.$fh.sync.getMetaData(datasetManager.datasetId, function(metadata) {
+      datasetManager.list().then(function(arrayOfDatasetItems) {
+        var listDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX, parameters.topicUid);
 
-      self.mediator.publish(listDoneTopic, arrayOfDatasetItems);
+        if (metadata.syncEvents) {
+          arrayOfDatasetItems.forEach(function(item) {
+            item._syncStatus = metadata.syncEvents[item.id];
+          });
+        }
+        self.mediator.publish(listDoneTopic, arrayOfDatasetItems);
+      }).catch(function(error) {
+        var listErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
 
-    }).catch(function(error) {
-
-      var listErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
-
-      self.mediator.publish(listErrorTopic, error);
+        self.mediator.publish(listErrorTopic, error);
+      });
     });
+
   };
 
 };

--- a/lib/client/mediator-subscribers/read-spec.js
+++ b/lib/client/mediator-subscribers/read-spec.js
@@ -37,10 +37,11 @@ describe("Sync Read Mediator Topic", function() {
 
   describe("No Error", function() {
     var doneTopic = "done:wfm:sync:mockdatasetid:read";
-
+    var mockMetaData = {};
     var mockDatasetManager = {
       datasetId: "mockdatasetid",
-      read: sinon.stub().resolves(mockDataItem)
+      read: sinon.stub().resolves(mockDataItem),
+      getMetaData: sinon.stub().callsArgWith(0, mockMetaData)
     };
 
     function checkMocks(readResult) {
@@ -90,6 +91,7 @@ describe("Sync Read Mediator Topic", function() {
   describe("Error", function() {
     var expectedTopicError = new Error("SYNC-Error-Code : Sync Error Message");
     var errorTopic = "error:wfm:sync:mockdatasetid:read";
+    var mockMetaData = {};
 
     function checkMocks(topicError) {
       expect(topicError).to.deep.equal(expectedTopicError);
@@ -100,7 +102,8 @@ describe("Sync Read Mediator Topic", function() {
 
     var mockDatasetManager = {
       datasetId: "mockdatasetid",
-      read: sinon.stub().rejects(expectedTopicError)
+      read: sinon.stub().rejects(expectedTopicError),
+      getMetaData: sinon.stub().callsArgWith(0, mockMetaData)
     };
 
     beforeEach(function() {
@@ -138,5 +141,95 @@ describe("Sync Read Mediator Topic", function() {
 
   });
 
+  describe("Sync Event", function() {
+    var doneTopic = "done:wfm:sync:mockdatasetid:read";
+    var mockMetaData = {
+      syncEvents: {
+        mockdataitemid: {
+          entityId: "mockdataitemid",
+          code: "mockEventCode",
+          action: "mockEventAction",
+          message: "mockEventMessage",
+          type: "mockEventType",
+          ts: sinon.match.number
+        }
+      }
+    };
+    var mockDatasetManager;
+
+    it("should add a sync status to the item read if there is any available", function() {
+      var testReadResultWithEvents = {
+        id: mockDataItem.id,
+        name: mockDataItem.name,
+        _syncStatus: mockMetaData.syncEvents[mockDataItem.id]
+      };
+
+      mockDatasetManager = {
+        datasetId: "mockdatasetid",
+        read: sinon.stub().resolves(mockDataItem),
+        getMetaData: sinon.stub().callsArgWith(0, mockMetaData)
+      };
+      mockDatasetManager.read.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.READ, require('./read')(syncSubscribers, mockDatasetManager));
+
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItem.id
+      });
+
+      return testDeferred.promise.then(function(readResult) {
+        sinon.assert.calledOnce(mockDatasetManager.read);
+        sinon.assert.calledOnce(mockDatasetManager.getMetaData);
+
+        sinon.assert.calledWith(mockDatasetManager.getMetaData, sinon.match.func);
+        sinon.assert.calledWith(mockDatasetManager.read, sinon.match(mockDataItem.id));
+
+        expect(readResult).to.deep.equal(testReadResultWithEvents);
+      });
+    });
+
+    it("should not add a sync status to the item read if no sync events exist for that item", function() {
+      var mockDataItemNoEvents = {
+        id: "mockDataItemNoEvents",
+        name: "This is a mock data item with no sync events"
+      };
+
+      var testReadResultNoEvents = {
+        id: mockDataItemNoEvents.id,
+        name: mockDataItemNoEvents.name,
+        _syncStatus: mockMetaData.syncEvents[mockDataItemNoEvents.id]
+      };
+
+      mockDatasetManager = {
+        datasetId: "mockdatasetid",
+        read: sinon.stub().resolves(mockDataItemNoEvents),
+        getMetaData: sinon.stub().callsArgWith(0, mockMetaData)
+      };
+
+      mockDatasetManager.read.reset();
+      syncSubscribers.on(CONSTANTS.TOPICS.READ, require('./read')(syncSubscribers, mockDatasetManager));
+
+      var testDeferred = q.defer();
+
+      this.subscribers[doneTopic] = mediator.subscribe(doneTopic, testDeferred.resolve);
+
+      mediator.publish(readTopic, {
+        id: mockDataItemNoEvents.id
+      });
+
+      return testDeferred.promise.then(function(readResult) {
+        sinon.assert.calledOnce(mockDatasetManager.read);
+        sinon.assert.calledOnce(mockDatasetManager.getMetaData);
+
+        sinon.assert.calledWith(mockDatasetManager.getMetaData, sinon.match.func);
+        sinon.assert.calledWith(mockDatasetManager.read, sinon.match(mockDataItemNoEvents.id));
+
+        expect(readResult).to.deep.equal(testReadResultNoEvents);
+      });
+    });
+  });
 
 });

--- a/lib/client/mediator-subscribers/read.js
+++ b/lib/client/mediator-subscribers/read.js
@@ -23,8 +23,9 @@ module.exports = function subscribeToReadTopic(syncDatasetTopics, datasetManager
     var self = this;
     parameters = parameters || {};
 
-    //Creating the item in the sync store
-    datasetManager.$fh.sync.getMetaData(datasetManager.datasetId, function(metadata) {
+
+    //Reading the item in the sync store
+    datasetManager.getMetaData(function(metadata) {
       datasetManager.read(parameters.id).then(function(itemRead) {
         var readDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, parameters.topicUid);
         if (metadata.syncEvents) {

--- a/lib/client/mediator-subscribers/read.js
+++ b/lib/client/mediator-subscribers/read.js
@@ -24,16 +24,21 @@ module.exports = function subscribeToReadTopic(syncDatasetTopics, datasetManager
     parameters = parameters || {};
 
     //Creating the item in the sync store
-    datasetManager.read(parameters.id).then(function(itemRead) {
-      var readDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+    datasetManager.$fh.sync.getMetaData(datasetManager.datasetId, function(metadata) {
+      datasetManager.read(parameters.id).then(function(itemRead) {
+        var readDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+        if (metadata.syncEvents) {
+          itemRead._syncStatus = metadata.syncEvents[itemRead.id];
+        }
+        self.mediator.publish(readDoneTopic, itemRead);
 
-      self.mediator.publish(readDoneTopic, itemRead);
+      }).catch(function(error) {
 
-    }).catch(function(error) {
+        var readErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
 
-      var readErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
-
-      self.mediator.publish(readErrorTopic, error);
+        self.mediator.publish(readErrorTopic, error);
+      });
     });
+
   };
 };

--- a/lib/client/mediator-subscribers/sync-events.js
+++ b/lib/client/mediator-subscribers/sync-events.js
@@ -1,7 +1,7 @@
-var CONSTANTS = require('../../constants');
   /**
  * Initialsing a subscriber for sync events.
  */
+
 module.exports = function syncEventSubscriber(datasetManager) {
 
   /**
@@ -10,7 +10,7 @@ module.exports = function syncEventSubscriber(datasetManager) {
    * @param {object} parameters
    */
   return function handleSyncEventTopics(parameters) {
-    if (parameters && parameters.uid && parameters.message && parameters.code !== CONSTANTS.SYNC_TOPICS.SYNC_COMPLETE) {
+    if (parameters && parameters.uid && parameters.message) {
       datasetManager.addEvent(parameters);
     }
   };

--- a/lib/client/mediator-subscribers/sync-events.js
+++ b/lib/client/mediator-subscribers/sync-events.js
@@ -1,4 +1,3 @@
-
 /**
  * Initialsing a subscriber for sync events.
  */

--- a/lib/client/mediator-subscribers/sync-events.js
+++ b/lib/client/mediator-subscribers/sync-events.js
@@ -1,4 +1,5 @@
-/**
+var CONSTANTS = require('../../constants');
+  /**
  * Initialsing a subscriber for sync events.
  */
 module.exports = function syncEventSubscriber(datasetManager) {
@@ -9,7 +10,7 @@ module.exports = function syncEventSubscriber(datasetManager) {
    * @param {object} parameters
    */
   return function handleSyncEventTopics(parameters) {
-    if (parameters && parameters.uid && parameters.message) {
+    if (parameters && parameters.uid && parameters.message && parameters.code !== CONSTANTS.SYNC_TOPICS.SYNC_COMPLETE) {
       datasetManager.addEvent(parameters);
     }
   };

--- a/lib/client/mediator-subscribers/sync-events.js
+++ b/lib/client/mediator-subscribers/sync-events.js
@@ -1,0 +1,17 @@
+
+/**
+ * Initialsing a subscriber for sync events.
+ */
+module.exports = function syncEventSubscriber(datasetManager) {
+
+  /**
+   * Handling the sync events
+   *
+   * @param {object} parameters
+   */
+  return function handleSyncEventTopics(parameters) {
+    if (parameters && parameters.uid && parameters.message) {
+      datasetManager.addEvent(parameters);
+    }
+  };
+};

--- a/lib/client/mediator-subscribers/update.js
+++ b/lib/client/mediator-subscribers/update.js
@@ -23,8 +23,11 @@ module.exports = function subscribeToUpdateTopic(syncDatasetTopics, datasetManag
     var self = this;
     parameters = parameters || {};
 
+    var datasetItemToUpdate = parameters.itemToUpdate;
+    delete datasetItemToUpdate._syncStatus;
+
     //Creating the item in the sync store
-    datasetManager.update(parameters.itemToUpdate).then(function(updatedDataSetItem) {
+    datasetManager.update(datasetItemToUpdate).then(function(updatedDataSetItem) {
       var creatDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
 
       self.mediator.publish(creatDoneTopic, updatedDataSetItem);

--- a/lib/client/mediator-subscribers/update.js
+++ b/lib/client/mediator-subscribers/update.js
@@ -24,6 +24,8 @@ module.exports = function subscribeToUpdateTopic(syncDatasetTopics, datasetManag
     parameters = parameters || {};
 
     var datasetItemToUpdate = parameters.itemToUpdate;
+
+    // remove _syncStatus, it can cause sync loop when updated and this data is irrelevant outside client
     delete datasetItemToUpdate._syncStatus;
 
     //Creating the item in the sync store

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,5 +12,9 @@ module.exports = {
     START: "start",
     STOP: "stop",
     FORCE_SYNC: "force_sync"
+  },
+  SYNC_TOPICS:{
+    REMOTE_UPDATE_APPLIED: "remote_update_applied",
+    REMOTE_UPDATE_FAILED: "remote_update_failed"
   }
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,9 +13,10 @@ module.exports = {
     STOP: "stop"
   },
   SYNC_TOPICS:{
-    COLLISION_DETECTED: "collision_detected",
-    REMOTE_UPDATE_APPLIED: "remote_update_applied",
-    REMOTE_UPDATE_FAILED: "remote_update_failed",
+    DATA:{
+      REMOTE_UPDATE_APPLIED: "remote_update_applied",
+      REMOTE_UPDATE_FAILED: "remote_update_failed"
+    },
     SYNC_COMPLETE: "sync_complete",
     FORCE_SYNC: "force_sync"
   }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,11 +10,13 @@ module.exports = {
     REMOVE: "remove",
     READ: "read",
     START: "start",
-    STOP: "stop",
-    FORCE_SYNC: "force_sync"
+    STOP: "stop"
   },
   SYNC_TOPICS:{
+    COLLISION_DETECTED: "collision_detected",
     REMOTE_UPDATE_APPLIED: "remote_update_applied",
-    REMOTE_UPDATE_FAILED: "remote_update_failed"
+    REMOTE_UPDATE_FAILED: "remote_update_failed",
+    SYNC_COMPLETE: "sync_complete",
+    FORCE_SYNC: "force_sync"
   }
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,10 +3,11 @@
 var defaultConfig = require('./config');
 var q = require('q');
 var _ = require('lodash');
+var debug = require('./utils/logger')(__filename);
 
 function initSync(mediator, mbaasApi, datasetId, syncOptions) {
   syncOptions = syncOptions || defaultConfig.syncOptions;
-
+  debug('Sync init');
   var dataListHandler = function(datasetId, queryParams, cb) {
     mediator.request('wfm:cloud:' + datasetId + ':list', queryParams, {uid: null, timeout: 5000})
       .then(function(data) {
@@ -16,7 +17,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
         });
         cb(null, syncData);
       }, function(error) {
-        console.log('Sync error: init:', datasetId, error);
+        debug('Sync error: init:', datasetId, error);
         cb(error);
       });
   };
@@ -31,7 +32,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
         };
         cb(null, res);
       }, function(error) {
-        console.log('Sync error: init:', datasetId, error);
+        debug('Sync error: init:', datasetId, error);
         cb(error);
       });
   };
@@ -41,7 +42,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       .then(function(object) {
         cb(null, object);
       }, function(error) {
-        console.log('Sync error: init:', datasetId, error);
+        debug('Sync error: init:', datasetId, error);
         cb(error);
       });
   };
@@ -51,7 +52,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       .then(function(object) {
         cb(null, object);
       }, function(error) {
-        console.log('Sync error: init:', datasetId, error);
+        debug('Sync error: init:', datasetId, error);
         cb(error);
       });
   };
@@ -61,7 +62,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
       .then(function(message) {
         cb(null, message);
       }, function(error) {
-        console.log('Sync error: init:', datasetId, error);
+        debug('Sync error: init:', datasetId, error);
         cb(error);
       });
   };
@@ -72,7 +73,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
   var deferred = q.defer();
   mbaasApi.sync.init(datasetId, syncOptions, function(err) {
     if (err) {
-      console.log('Sync error: init:', datasetId, err);
+      debug('Sync error: init:', datasetId, err);
       deferred.reject(err);
     } else {
       mbaasApi.sync.handleList(datasetId, dataListHandler);

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,0 +1,12 @@
+var _ = require('lodash');
+var name = require('../../package.json').name;
+var path = require('path').normalize(__dirname +'/../../');
+
+/**
+ * Function returning debug logger with prebuild signature
+ * @param filePath path of the file where logger will be used
+ */
+module.exports = function setupLogger(filePath) {
+  var str = filePath.substring(filePath.indexOf(path)).replace(path, name+':');
+  return require('debug')(_.trim(str.split('/').join(':'), '.js') + ':');
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.3.0-alpha.504.1",
+  "version": "0.3.0",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.2.0",
+  "version": "0.3.0-alpha.504.1",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "repository": {
@@ -21,6 +21,7 @@
   "author": "Sebastien Blanc, Brian Leathem",
   "license": "MIT",
   "dependencies": {
+    "debug": "^2.6.3",
     "fh-wfm-mediator": "0.3.2",
     "lodash": "4.7.0",
     "q": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "angular-mocks": "1.5.3",
     "async": "1.5.0",
     "bunyan": "1.8.0",
-    "chai": "^3.5.0",
+    "chai": "3.5.0",
     "config-chain": "1.1.10",
     "cors": "2.7.1",
     "dotenv": "2.0.0",


### PR DESCRIPTION
WIP based of @nialldonnellyfh changes.

# What
Update the module to handle sync remote events

# How
- added subscribers for all sync events
- each time the result is listed or read `syncStatus` property is added/updated

# JIRA
https://issues.jboss.org/browse/RAINCATCH-504
https://issues.jboss.org/browse/RAINCATCH-475
https://issues.jboss.org/browse/RAINCATCH-507