### PR TITLE
Update server `syncFrequency` value to match client `sync_frequency`

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,12 +509,21 @@ Check a complete example [here](https://github.com/feedhenry-staff/wfm-workorder
 {
   datasetId : 'workorders',
   syncOptions : {
+    "syncFrequency": 5,
     "sync_frequency" : 5,
     "storage_strategy": "dom",
     "do_console_log": false
   }
 }
 ```
+
+##### Sync frequencies
+
+Sync frequency is set individually for the client and the server.
+* On the client the setting is named `sync_frequency`.
+* On the server the setting is named `syncFrequency`.
+
+It is recommended that these settings share the same value.
 
 ##### Custom data collision handler setup
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,11 @@
 'use strict';
 
+var SYNC_FREQUENCY = 5;
+
 module.exports = {
   syncOptions : {
-    "sync_frequency" : 5,
+    "syncFrequency": SYNC_FREQUENCY,
+    "sync_frequency" : SYNC_FREQUENCY,
     "storage_strategy": "dom",
     "do_console_log": false
   }


### PR DESCRIPTION
Identical reasons as https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud/pull/90.

If the client-side dataset `sync_frequency` config defaults to 5 seconds then the server-side
`syncFrequency` config should also.