### PR TITLE
Rhmap 15172 ensure fh sync manage is called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 services:
   - docker
 script:
-  - npm run-script grunt-eslint
+  - npm test
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/lib/client/client-spec.js
+++ b/lib/client/client-spec.js
@@ -63,14 +63,40 @@ describe("Raincatcher Sync Client Initialisation", function() {
     sinon.assert.calledOnce(self.mock$fh.sync.notify);
   });
 
-  it("should create a new data manager when managing a new data set", function() {
-    var self = this;
-    return syncClient.manage(mockDataSetId, mockSyncOptions, mockDataSetFilterParams, mockDataSetMetadataParams).then(function(datasetManager) {
-      sinon.assert.calledOnce(self.mock$fh.sync.manage);
-      sinon.assert.calledWith(self.mock$fh.sync.manage, sinon.match(mockDataSetId), sinon.match(mockSyncOptions), sinon.match(mockDataSetFilterParams), sinon.match(mockDataSetMetadataParams));
+  describe("Managing Data Sets", function() {
 
-      datasetManager.removeSyncDataTopicSubscribers();
+    var datasetManager;
+
+    it("should create a new data manager when managing a new data set", function() {
+      var self = this;
+      return syncClient.manage(mockDataSetId, mockSyncOptions, mockDataSetFilterParams, mockDataSetMetadataParams).then(function(_datasetManager) {
+        datasetManager = _datasetManager;
+        sinon.assert.calledOnce(self.mock$fh.sync.manage);
+        sinon.assert.calledWith(self.mock$fh.sync.manage, sinon.match(mockDataSetId), sinon.match(mockSyncOptions), sinon.match(mockDataSetFilterParams), sinon.match(mockDataSetMetadataParams));
+
+        datasetManager.removeSyncDataTopicSubscribers();
+      });
+    });
+
+    it("should only create a single data manager when managing a new data set", function() {
+      var filter2 = {filter: {filter2: "filter2value"}};
+
+      var self = this;
+      return syncClient.manage(mockDataSetId, mockSyncOptions, filter2, mockDataSetMetadataParams)
+        .then(function(datasetManager2) {
+
+          //Calling manage more than once should ensure that $fh.sync.manage should be called again.
+          sinon.assert.calledTwice(self.mock$fh.sync.manage);
+          sinon.assert.calledWith(self.mock$fh.sync.manage,
+            sinon.match(mockDataSetId), sinon.match(mockSyncOptions),
+            sinon.match(filter2),
+            sinon.match(mockDataSetMetadataParams));
+
+          //The same dataset manager should be used.
+          expect(datasetManager).to.equal(datasetManager2);
+        });
     });
   });
+
 
 });

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -11,7 +11,7 @@ var $fh,
   initialized = false,
   syncNotificationStream,
   syncNotifyListeners = [],
-  mediator, dataSetManagerPromises = {};
+  mediator, dataSetManagers = {};
 
 /**
  *
@@ -101,16 +101,14 @@ function manage(datasetId, options, queryParams, metaData) {
     return deferred.promise;
   }
 
-  //If there is already a manager initialising for this dataset, return the promise.
-  if (dataSetManagerPromises[datasetId]) {
-    return dataSetManagerPromises[datasetId];
-  }
-
-  var deferredManagerDeferred = q.defer();
-  dataSetManagerPromises[datasetId] = deferredManagerDeferred.promise;
-
   //Using the $fh.sync API to manage a single data set with the passed parameters above.
   $fh.sync.manage(datasetId, options, queryParams, metaData, function() {
+
+    //If the manager for this data set already exists, no need to create a new one.
+    if (dataSetManagers[datasetId]) {
+      return deferred.resolve(dataSetManagers[datasetId]);
+    }
+
     //Creating another observable stream that is filtered by the ID of th data set created.
     //This ensures that the created manager only gets notifications for the relevant data set.
     var dataSetNotificationStream = syncNotificationStream.filter(function(syncNotification) {
@@ -119,12 +117,12 @@ function manage(datasetId, options, queryParams, metaData) {
 
     //Creating a single manager for the data set.
     //This is used to encapsulate all of the functionality available to a single data set (E.g. CRDUL operations for workorders).
-    var manager = new DataManager(datasetId, $fh, dataSetNotificationStream, mediator);
+    dataSetManagers[datasetId] = new DataManager(datasetId, $fh, dataSetNotificationStream, mediator);
 
-    deferredManagerDeferred.resolve(manager);
+    deferred.resolve(dataSetManagers[datasetId]);
   });
 
-  return dataSetManagerPromises[datasetId];
+  return deferred.promise;
 }
 
 

--- a/lib/client/mediator-subscribers/force-sync-spec.js
+++ b/lib/client/mediator-subscribers/force-sync-spec.js
@@ -43,7 +43,7 @@ describe("Sync Force Sync Mediator Topic", function() {
 
     beforeEach(function() {
       mockDatasetManager.forceSync.reset();
-      syncSubscribers.on(CONSTANTS.TOPICS.FORCE_SYNC, require('./force-sync')(syncSubscribers, mockDatasetManager));
+      syncSubscribers.on(CONSTANTS.SYNC_TOPICS.FORCE_SYNC, require('./force-sync')(syncSubscribers, mockDatasetManager));
     });
 
     it("should handle no unique topic id", function() {

--- a/lib/client/mediator-subscribers/force-sync.js
+++ b/lib/client/mediator-subscribers/force-sync.js
@@ -24,11 +24,11 @@ module.exports = function subscribeToForceSyncTopic(syncDatasetTopics, datasetMa
 
     //Creating the item in the sync store
     datasetManager.forceSync().then(function() {
-      var forceSyncDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+      var forceSyncDoneTopic = syncDatasetTopics.getTopic(CONSTANTS.SYNC_TOPICS.FORCE_SYNC, CONSTANTS.DONE_PREFIX, parameters.topicUid);
       self.mediator.publish(forceSyncDoneTopic);
 
     }).catch(function(error) {
-      var forceSyncErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+      var forceSyncErrorTopic = syncDatasetTopics.getTopic(CONSTANTS.SYNC_TOPICS.FORCE_SYNC, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
       self.mediator.publish(forceSyncErrorTopic, error);
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-sync",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An sync module for WFM",
   "main": "lib/angular/sync-ng.js",
   "repository": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.host.url=https://sonarqube.com
 sonar.projectKey=raincatcher-sync
 sonar.projectName=raincatcher-sync
-sonar.projectVersion=0.0.13
+sonar.projectVersion=0.3.2
 
 sonar.sources=./lib
 sonar.language=js


### PR DESCRIPTION
# Motivation

When the $fh.sync.manage function is called for the same data set, the options are overridden.

This should be the same for the `syncClient.manage` function. Otherwise any changed parameters passed to syncClient.manage would not be respected.

We can still use the same dataManager for topics.