### PR TITLE
[Preview only] Remove mediator from sync cloud

### DIFF
--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,0 +1,100 @@
+var _ = require('lodash');
+
+function buildQuery(query, fields, expression) {
+  var field;
+  if (null !== fields) {
+    for (field in  fields) {
+      if (fields.hasOwnProperty(field)) {
+        var queryField = {};
+        if ('undefined' !== typeof query[field]) {
+          queryField = query[field];
+        }
+        queryField[expression] = fields[field];
+        query[field] = queryField;
+      }
+    }
+  }
+}
+
+
+var crit_ops = {
+  eq: function(query, fields) {
+    var field;
+    if (null !== fields) {
+      for (field in  fields) {
+        if (fields.hasOwnProperty(field)) {
+          query[field] = fields[field];
+        }
+      }
+    }
+  },
+  ne: function(query, fields) {
+    buildQuery(query, fields, "$ne");
+  },
+  lt: function(query, fields) {
+    buildQuery(query, fields, "$lt");
+  },
+  le: function(query, fields) {
+    buildQuery(query, fields, "$lte");
+  },
+  gt: function(query, fields) {
+    buildQuery(query, fields, "$gt");
+  },
+  ge: function(query, fields) {
+    buildQuery(query, fields, "$gte");
+  },
+  like: function(query, fields) {
+    buildQuery(query, fields, "$regex");
+  },
+  "in": function(query, fields) {
+    buildQuery(query, fields, "$in");
+  },
+  geo: function(query, fields) {
+    if (null !== fields) {
+      var field;
+      var earthRadius = 6378; //km
+      for (field in  fields) {
+        if (fields.hasOwnProperty(field)) {
+          var queryField = {};
+          if ('undefined' !== typeof query[field]) {
+            queryField = query[field];
+          }
+          queryField["$within"] = {
+            "$centerSphere": [  // supported by mongodb V1.8 & above
+              fields[field].center,
+              fields[field].radius / earthRadius
+            ]
+          };
+          query[field] = queryField;
+        }
+      }
+    }
+  }
+};
+
+/**
+ *
+ * Creating a mongo query from $fh.db query params
+ *
+ * See https://access.redhat.com/documentation/en-us/red_hat_mobile_application_platform_hosted/3/html/cloud_api/fh-db for more details
+ *
+ * @param filterParams
+ * @returns {{}}
+ */
+module.exports = function createQuery(filterParams) {
+  var query = {};
+
+  if (filterParams && filterParams.key && filterParams.value) {
+    filterParams.eq = {};
+    filterParams.eq[String(filterParams.key)] = String(filterParams.value);
+  }
+
+  _.each(crit_ops, function(critOpFunction, op) {
+    var fields_values = filterParams[op];
+    if (fields_values) {
+      crit_ops[op](query, fields_values);
+    }
+  });
+
+  return query;
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -74,8 +74,7 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions, store) {
     } else {
       return cb("Expected the object to have either an id or _localuid field");
     }
-    return store.db.collection(self.datasetId).replaceOne(query, data,
-      { wtimeout: 10000 }).then(function () {
+    return store.db.collection(self.datasetId).replaceOne(query, data).then(function () {
         return cb(null, data);
       }).catch(function (err) {
         return cb(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,11 +5,16 @@ var q = require('q');
 var _ = require('lodash');
 var debug = require('./utils/logger')(__filename);
 var CONSTANTS = require('./constants');
+var buildQuery = require('./db/query');
 
 var semver = require('semver');
 var shortid = require('shortid');
-
-function initSync(mediator, mbaasApi, datasetId, syncOptions) {
+/**
+ * @param {*} store 
+ * store.db - mongoConnection
+ * store.dataListHandler etc. override for custom data handling
+ */
+function initSync(mediator, mbaasApi, datasetId, syncOptions, store) {
   syncOptions = syncOptions || defaultConfig.syncOptions;
   debug('Sync init');
   //start the sync service
@@ -22,73 +27,88 @@ function initSync(mediator, mbaasApi, datasetId, syncOptions) {
   }
 
   var dataListHandler = function(datasetId, queryParams, metadata, cb) {
-
+    if (store.dataListHandler) {
+      return store.dataListHandler(datasetId, queryParams, metadata, cb);
+    }
     queryParams = queryParams || {};
 
-    var uid = shortid.generate();
-    queryParams.topicUid = uid;
+    var query = buildQuery(queryParams);
+    var resultPromise = store.db.collection(datasetId).find(query);
 
-    mediator.request('wfm:cloud:' + datasetId + ':list', queryParams, {uid: uid, timeout: 3000})
-      .then(function(data) {
-        var syncData = {};
-        data.forEach(function(object) {
-          syncData[object.id] = object;
-        });
-
-        cb(null, syncData);
-      }, function(error) {
-        debug('Sync error: init:', datasetId, error);
-        cb(error);
-      });
+    if (queryParams.sort && typeof queryParams.sort === 'object') {
+      resultPromise = resultPromise.sort(queryParams.sort);
+    }
+    return resultPromise.toArray().then(function(list){
+      return cb(null, list);
+    }).catch(function (err) {
+      return cb(err);
+    });
   };
 
   var dataCreateHandler = function(datasetId, data, metadata, cb) {
-    var ts = new Date().getTime();  // TODO: replace this with a proper uniqe (eg. a cuid)
-    mediator.request('wfm:cloud:' + datasetId + ':create', [data, ts], {uid: ts})
-      .then(function(object) {
-        var res = {
-          "uid": object.id,
-          "data": object
-        };
-        cb(null, res);
-      }, function(error) {
-        debug('Sync error: init:', datasetId, error);
-        cb(error);
-      });
+    if (store.dataCreateHandler) {
+      return store.dataCreateHandler(datasetId, queryParams, metadata, cb);
+    }
+    store.db.collection(datasetId).insertOne(data).then(function () {
+      return cb(null, data);
+    }).catch(function (err) {
+      return cb(err);
+    });
   };
 
   var dataSaveHandler = function(datasetId, uid, data, metadata, cb) {
-    mediator.request('wfm:cloud:' + datasetId + ':update', data, {uid: uid})
-      .then(function(object) {
-        cb(null, object);
-      }, function(error) {
-        debug('Sync error: init:', datasetId, error);
-        cb(error);
+   if (store.dataSaveHandler) {
+      return store.dataSaveHandler(datasetId, queryParams, metadata, cb);
+    }
+    var query;
+    if (!_.isObject(data)) {
+      return cb("Expected an object to update");
+    }
+    if (data._id) {
+      delete data._id;
+    }
+    if (data.id) {
+      query = { id: data.id };
+    } else if (data._localuid) {
+      query = { _localuid: data._localuid };
+    } else {
+      return cb("Expected the object to have either an id or _localuid field");
+    }
+    return store.db.collection(self.datasetId).replaceOne(query, data,
+      { wtimeout: 10000 }).then(function () {
+        return cb(null, data);
+      }).catch(function (err) {
+        return cb(err);
       });
   };
 
   var dataGetHandler = function(datasetId, uid, metadata, cb) {
-    mediator.request('wfm:cloud:' + datasetId + ':read', uid)
-      .then(function(object) {
-        cb(null, object);
-      }, function(error) {
-        debug('Sync error: init:', datasetId, error);
-        cb(error);
+    if (store.dataGetHandler) {
+      return store.dataGetHandler(datasetId, queryParams, metadata, cb);
+    }
+    store.db.collection(datasetId).findOne({ id: uid }, { _id: 0 })
+      .then(function (result) {
+        if (!result) {
+          return Promise.reject();
+        }
+        return cb(null, result);
+      }).catch(function (err) {
+        return cb(err);
       });
   };
 
   var dataDeleteHandler = function(datasetId, uid, metadata, cb) {
-    mediator.request('wfm:cloud:' + datasetId + ':delete', uid)
-      .then(function(message) {
-        cb(null, message);
-      }, function(error) {
-        debug('Sync error: init:', datasetId, error);
-        cb(error);
-      });
+    if (store.dataDeleteHandler) {
+      return store.dataDeleteHandler(datasetId, queryParams, metadata, cb);
+    }
+    store.db.collection(datasetId).deleteOne({ id: uid }).then(function (object) {
+      return cb(null, object);
+    }).catch(function (err) {
+      return cb(err);
+    });
   };
 
   var collisionHandler = syncOptions.dataCollisionHandler;
-
 
   mbaasApi.sync.init(datasetId, syncOptions, function(err) {
     if (err) {


### PR DESCRIPTION
## Motivation

This PR is an attempt to strip out all mediator calls from sync related operations.
When using this changes in code we will not longer use mediator in node.js server side calls.

**This change is not production ready!** Please do not merge it.
I did not executed any performance tests to compare results as we will need to do that after integrating this module. We still need to carefully test this before applying to production.

## Technical info

By this we avoiding 5 additional "hops" using mediator channels and fetching data directly in sync.
This change will require users to pass their mongo connection to each sync init call. Additionally any crud methods can be overriden by developers (as it was supported before).

## Integration

Pass mongodb driver connection to: 
https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud/blob/master/lib/initSync.js#L34

ping  @dcawlio @david-martin @johnfriz 